### PR TITLE
[Refactor] #16 : 인증 내부 로직 변경

### DIFF
--- a/src/main/java/trying/cosmos/domain/course/CourseController.java
+++ b/src/main/java/trying/cosmos/domain/course/CourseController.java
@@ -32,16 +32,14 @@ public class CourseController {
         );
     }
 
-    @AuthorityOf(Authority.USER)
     @GetMapping("/{id}")
     public CourseFindResponse find(@PathVariable Long id) {
-        return new CourseFindResponse(courseService.find(AuthKey.get(), id), courseService.isLiked(AuthKey.get(), id));
+        return courseService.find(AuthKey.isAuthenticated() ? AuthKey.get() : null, id);
     }
 
-    @AuthorityOf(Authority.USER)
     @GetMapping
     public CourseListFindResponse findList(Pageable pageable) {
-        return new CourseListFindResponse(courseService.findFeeds(AuthKey.get(), pageable));
+        return new CourseListFindResponse(courseService.findCourses(AuthKey.isAuthenticated() ? AuthKey.get() : null, pageable));
     }
 
     @AuthorityOf(Authority.USER)

--- a/src/main/java/trying/cosmos/domain/course/CourseRepository.java
+++ b/src/main/java/trying/cosmos/domain/course/CourseRepository.java
@@ -15,6 +15,11 @@ public interface CourseRepository extends JpaRepository<Course, Long>{
 
     Slice<Course> findAllByPlanet(Planet planet, Pageable pageable);
 
+    //
     @Query("select c from Course c where c.planet = :planet and c.access = trying.cosmos.domain.course.Access.PUBLIC")
     Slice<Course> findPublicByPlanet(Planet planet, Pageable pageable);
+
+    // 모든 코스 조회, 내 행성의 코스인 경우 모든 코스, 다른 행성의 코스인 경우 PUBLIC 코스만
+    @Query("select c from Course c where c.planet = :planet or c.access = trying.cosmos.domain.course.Access.PUBLIC")
+    Slice<Course> findAll(Planet planet, Pageable pageable);
 }

--- a/src/main/java/trying/cosmos/domain/course/response/CourseFindContent.java
+++ b/src/main/java/trying/cosmos/domain/course/response/CourseFindContent.java
@@ -15,11 +15,13 @@ public class CourseFindContent {
     private PlanetFindResponse planet;
     private String title;
     private String createdDate;
+    private boolean liked;
 
-    public CourseFindContent(Course course) {
+    public CourseFindContent(Course course, boolean liked) {
         this.id = course.getId();
         this.planet = new PlanetFindResponse(course.getPlanet());
         this.title = course.getTitle();
         this.createdDate = DateUtils.getFormattedDate(course.getCreatedDate());
+        this.liked = liked;
     }
 }

--- a/src/main/java/trying/cosmos/domain/course/response/CourseListFindResponse.java
+++ b/src/main/java/trying/cosmos/domain/course/response/CourseListFindResponse.java
@@ -4,10 +4,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
-import trying.cosmos.domain.course.Course;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,8 +15,8 @@ public class CourseListFindResponse {
     private int size;
     private boolean hasNext;
 
-    public CourseListFindResponse(Slice<Course> courseSlice) {
-        this.courses = courseSlice.getContent().stream().map(CourseFindContent::new).collect(Collectors.toList());
+    public CourseListFindResponse(Slice<CourseFindContent> courseSlice) {
+        this.courses = courseSlice.getContent();
         this.size = courseSlice.getNumberOfElements();
         this.hasNext = courseSlice.hasNext();
     }

--- a/src/main/java/trying/cosmos/domain/planet/PlanetController.java
+++ b/src/main/java/trying/cosmos/domain/planet/PlanetController.java
@@ -53,10 +53,9 @@ public class PlanetController {
         return new PlanetListFindResponse(planetService.searchPlanets(query, pageable));
     }
 
-    @AuthorityOf(Authority.USER)
     @GetMapping("/{id}/courses")
     public PlanetCourseListResponse findPlanetCourses(@PathVariable Long id, Pageable pageable) {
-        return new PlanetCourseListResponse(planetService.findPlanetCourses(AuthKey.get(), id, pageable));
+        return new PlanetCourseListResponse(planetService.findPlanetCourses(AuthKey.isAuthenticated() ? AuthKey.get() : null, id, pageable));
     }
 
     @AuthorityOf(Authority.USER)

--- a/src/main/java/trying/cosmos/domain/planet/PlanetService.java
+++ b/src/main/java/trying/cosmos/domain/planet/PlanetService.java
@@ -53,10 +53,17 @@ public class PlanetService {
 
     public Slice<Course> findPlanetCourses(Long userId, Long planetId, Pageable pageable) {
         Planet planet = planetRepository.findById(planetId).orElseThrow();
+        // 익명의 사용자
+        if (userId == null) {
+            return courseRepository.findPublicByPlanet(planet, pageable);
+        }
+
         User user = userRepository.findById(userId).orElseThrow();
         if (planet.beOwnedBy(user)) {
+            // 내 행성
             return courseRepository.findAllByPlanet(planet, pageable);
         } else {
+            // 다른 사람 행성
             return courseRepository.findPublicByPlanet(planet, pageable);
         }
     }

--- a/src/main/java/trying/cosmos/global/auth/TokenProvider.java
+++ b/src/main/java/trying/cosmos/global/auth/TokenProvider.java
@@ -13,6 +13,8 @@ import trying.cosmos.global.exception.CustomException;
 import trying.cosmos.global.exception.ExceptionType;
 
 import java.security.Key;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 public class TokenProvider {
@@ -33,6 +35,17 @@ public class TokenProvider {
                 .claim(AUTHORITY_KEY, user.getAuthority())
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
+    }
+
+    public Map<String, String> parseToken(String accessToken) {
+        Map<String, String> data = new HashMap<>();
+        Claims claims = parseClaims(accessToken);
+        if (claims.get(SUBJECT_KEY) == null || claims.get(AUTHORITY_KEY) == null) {
+            throw new CustomException(ExceptionType.AUTHENTICATION_FAILED);
+        }
+        data.put(SUBJECT_KEY, claims.getSubject());
+        data.put(AUTHORITY_KEY, claims.get(AUTHORITY_KEY, String.class));
+        return data;
     }
 
     public String getSubject(String accessToken) {

--- a/src/main/java/trying/cosmos/global/configuration/WebConfig.java
+++ b/src/main/java/trying/cosmos/global/configuration/WebConfig.java
@@ -6,6 +6,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import trying.cosmos.domain.user.UserRepository;
+import trying.cosmos.global.auth.AnonymousInterceptor;
 import trying.cosmos.global.auth.AuthenticationInterceptor;
 import trying.cosmos.global.auth.TokenProvider;
 
@@ -19,6 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthenticationInterceptor(userRepository, tokenProvider));
+        registry.addInterceptor(new AnonymousInterceptor(userRepository, tokenProvider));
     }
 
     @Override

--- a/src/main/java/trying/cosmos/global/utils/dev/DevController.java
+++ b/src/main/java/trying/cosmos/global/utils/dev/DevController.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import trying.cosmos.domain.user.User;
+import trying.cosmos.global.auth.TokenProvider;
 import trying.cosmos.global.utils.dev.response.DevCreateUserResponse;
 import trying.cosmos.global.utils.dev.response.DevPlanetResponse;
 
@@ -15,14 +17,17 @@ import trying.cosmos.global.utils.dev.response.DevPlanetResponse;
 public class DevController {
 
     private final DevService devService;
+    private final TokenProvider tokenProvider;
 
     @PostMapping("/users")
     public DevCreateUserResponse createUser() {
-        return new DevCreateUserResponse(devService.createUser());
+        User user = devService.createUser();
+        return new DevCreateUserResponse(user, tokenProvider.getAccessToken(user));
     }
 
     @PostMapping("/planets")
     public DevPlanetResponse createPlanet() {
-        return new DevPlanetResponse(devService.createPlanet());
+        User user = devService.createUser();
+        return new DevPlanetResponse(devService.createPlanet(user), tokenProvider.getAccessToken(user));
     }
 }

--- a/src/main/java/trying/cosmos/global/utils/dev/DevService.java
+++ b/src/main/java/trying/cosmos/global/utils/dev/DevService.java
@@ -30,12 +30,12 @@ public class DevService {
     @Transactional
     public User createUser() {
         String str = randomName();
-        return userRepository.save(new User(str + "@gmail.com", "password", str, UserStatus.LOGOUT, Authority.USER));
+        return userRepository.save(new User(str + "@gmail.com", "password", str, UserStatus.LOGIN, Authority.USER));
     }
 
     @Transactional
-    public Planet createPlanet() {
-        return planetRepository.save(new Planet(createUser(), randomName(), PlanetImageType.EARTH));
+    public Planet createPlanet(User user) {
+        return planetRepository.save(new Planet(user, randomName(), PlanetImageType.EARTH));
     }
 
     private String randomName() {

--- a/src/main/java/trying/cosmos/global/utils/dev/response/DevCreateUserResponse.java
+++ b/src/main/java/trying/cosmos/global/utils/dev/response/DevCreateUserResponse.java
@@ -12,9 +12,12 @@ public class DevCreateUserResponse {
     private String email;
     private String password;
     private String name;
-    public DevCreateUserResponse(User user) {
+    private String accessToken;
+
+    public DevCreateUserResponse(User user, String accessToken) {
         this.email = user.getEmail();
         this.password = "password";
         this.name = user.getName();
+        this.accessToken = accessToken;
     }
 }

--- a/src/main/java/trying/cosmos/global/utils/dev/response/DevPlanetResponse.java
+++ b/src/main/java/trying/cosmos/global/utils/dev/response/DevPlanetResponse.java
@@ -12,8 +12,8 @@ public class DevPlanetResponse {
     private DevCreateUserResponse owner;
     private DevPlanetContent planet;
 
-    public DevPlanetResponse(Planet planet) {
-        this.owner = new DevCreateUserResponse(planet.getOwners().get(0));
+    public DevPlanetResponse(Planet planet, String accessToken) {
+        this.owner = new DevCreateUserResponse(planet.getOwners().get(0), accessToken);
         this.planet = new DevPlanetContent(planet);
     }
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -576,7 +576,7 @@ Host: 15.165.72.196:3059
 
 {
   "email" : "email@gmail.com",
-  "code" : "XzvAOp"
+  "code" : "PyFDjn"
 }</code></pre>
 </div>
 </div>
@@ -1312,7 +1312,7 @@ Content-Length: 65
 
 {
   "id" : 6,
-  "code" : "6744aedd-0c76-43e5-a741-d91ed473bdaa"
+  "code" : "44540748-9e23-48f3-a2bb-f8774d0e78b4"
 }</code></pre>
 </div>
 </div>
@@ -1404,7 +1404,7 @@ Content-Type: application/json
 Content-Length: 53
 
 {
-  "code" : "684e46d9-d3dd-4c9b-9a96-2486e7a13f28"
+  "code" : "e619ca23-e8ac-4ea2-b80d-bd3a6b2535fa"
 }</code></pre>
 </div>
 </div>
@@ -1445,7 +1445,7 @@ Content-Length: 53
 <h4 id="_request_13"><a class="link" href="#_request_13">Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /planets/join?code=d3898fc7-21cf-40c4-afcf-b672b37c7590 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /planets/join?code=873bfc33-19ae-4458-b885-7c897c010d66 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 accessToken: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJlbWFpbEBnbWFpbC5jb20iLCJhdXRoIjoiVVNFUiJ9.9DI3jansyUxSnl3v0Fu-wSmwERgkEpVZpVq1V5CfIVtdk9a5OUede6xtC4cfDaIhKStu_sWZro_L_-6JDwbMqA
 Host: 15.165.72.196:3059</code></pre>
@@ -1560,7 +1560,7 @@ Content-Length: 53
 Host: 15.165.72.196:3059
 
 {
-  "code" : "41d613af-16b5-40c4-afac-454384e9a545"
+  "code" : "63c6c1e8-9a11-424b-be50-26c98f9c0daf"
 }</code></pre>
 </div>
 </div>
@@ -2231,7 +2231,7 @@ Content-Length: 715
 {
   "title" : "효자시장 맛집코스",
   "body" : "굿",
-  "createdDate" : "2022-10-17 23:56:19",
+  "createdDate" : "2022-10-18 11:21:14",
   "liked" : false,
   "planet" : {
     "id" : 3,
@@ -2410,7 +2410,7 @@ Host: 15.165.72.196:3059</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 471
+Content-Length: 513
 
 {
   "courses" : [ {
@@ -2421,7 +2421,8 @@ Content-Length: 471
       "image" : "EARTH"
     },
     "title" : "효자시장 맛집코스",
-    "createdDate" : "2022-10-17 23:56:20"
+    "createdDate" : "2022-10-18 11:21:14",
+    "liked" : false
   }, {
     "id" : 6,
     "planet" : {
@@ -2430,7 +2431,8 @@ Content-Length: 471
       "image" : "EARTH"
     },
     "title" : "한번쯤 가볼만한 식당 리스트",
-    "createdDate" : "2022-10-17 23:56:20"
+    "createdDate" : "2022-10-18 11:21:14",
+    "liked" : false
   } ],
   "size" : 2,
   "hasNext" : false
@@ -2480,6 +2482,11 @@ Content-Length: 471
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>courses[].createdDate</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">코스 생성일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>courses[].liked</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">코스 좋아요 여부</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>

--- a/src/test/java/trying/cosmos/docs/CourseDocsTest.java
+++ b/src/test/java/trying/cosmos/docs/CourseDocsTest.java
@@ -198,6 +198,7 @@ public class CourseDocsTest {
                         fieldWithPath("courses[].planet.image").description("코스가 포함된 행성 이미지 타입"),
                         fieldWithPath("courses[].title").description("코스 제목"),
                         fieldWithPath("courses[].createdDate").description("코스 생성일"),
+                        fieldWithPath("courses[].liked").description("코스 좋아요 여부"),
                         fieldWithPath("size").description("불러온 코스 수"),
                         fieldWithPath("hasNext").description("다음 페이지 존재 여부")
                 )


### PR DESCRIPTION
## 🔍 Issue
- Close #16

## 📝 Task
- 인증 메서드 인터셉터와 비인증 메서드 인터셉터를 분리
- 비인증 메서드도 accessToken이 존재한다면 인증할 수 있다.
- 행성 조회, 코스 조회를 기존 USER 권한에서 권한 없음으로 변경
- 코스 좋아요 확인 기능 추가
  - 로그인하지 않은 경우에는 좋아요 X
- Dev controller에서 사용자 생성, 행성 생성시 자동으로 로그인되게 변경

## 🐥 Issue
- 코드가 좀 지저분하다

## 📆 Todo
- 코드 정리
