### PR TITLE
[Docs] #35 : Rest Docs 커스텀

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -12,8 +12,6 @@ ifndef::snippets[]
 :snippets: ./build/generated-snippets
 endif::[]
 
-== {postman}[API Test]
-
 [[Certification]]
 == Certification
 
@@ -22,11 +20,11 @@ endif::[]
 - 회원가입시 이메일을 인증하기 위한 코드를 전송
 
 **Request**
-include::{snippets}/certification/create-certification/http-request.adoc[]
-include::{snippets}/certification/create-certification/request-fields.adoc[]
+include::{snippets}/certification-docs-test/create_certification/http-request.adoc[]
+include::{snippets}/certification-docs-test/create_certification/request-fields.adoc[]
 
 **Response**
-include::{snippets}/certification/create-certification/http-response.adoc[]
+include::{snippets}/certification-docs-test/create_certification/http-response.adoc[]
 
 '''
 
@@ -35,11 +33,11 @@ include::{snippets}/certification/create-certification/http-response.adoc[]
 - 이메일로 받은 인증코드를 확인
 
 ==== Request
-include::{snippets}/certification/certificate/http-request.adoc[]
-include::{snippets}/certification/certificate/request-fields.adoc[]
+include::{snippets}/certification-docs-test/certificate/http-request.adoc[]
+include::{snippets}/certification-docs-test/certificate/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/certification/certificate/http-response.adoc[]
+include::{snippets}/certification-docs-test/certificate/http-response.adoc[]
 
 [[User]]
 == User
@@ -49,11 +47,11 @@ include::{snippets}/certification/certificate/http-response.adoc[]
 - 인증받은 이메일로 가입해야 한다
 
 ==== Request
-include::{snippets}/user/join/http-request.adoc[]
-include::{snippets}/user/join/request-fields.adoc[]
+include::{snippets}/user-docs-test/join/http-request.adoc[]
+include::{snippets}/user-docs-test/join/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/user/join/http-response.adoc[]
+include::{snippets}/user-docs-test/join/http-response.adoc[]
 
 '''
 
@@ -61,12 +59,12 @@ include::{snippets}/user/join/http-response.adoc[]
 - 로그인시 해당 이메일이 존재하는지 확인
 
 ==== Request
-include::{snippets}/user/check-email/http-request.adoc[]
-include::{snippets}/user/check-email/request-parameters.adoc[]
+include::{snippets}/user-docs-test/check_email/http-request.adoc[]
+include::{snippets}/user-docs-test/check_email/request-parameters.adoc[]
 
 ==== Response
-include::{snippets}/user/check-email/http-response.adoc[]
-include::{snippets}/user/check-email/response-fields.adoc[]
+include::{snippets}/user-docs-test/check_email/http-response.adoc[]
+include::{snippets}/user-docs-test/check_email/response-fields.adoc[]
 
 '''
 
@@ -74,34 +72,34 @@ include::{snippets}/user/check-email/response-fields.adoc[]
 - 사용자 인증을 위한 토큰 반환
 
 ==== Request
-include::{snippets}/user/login/http-request.adoc[]
-include::{snippets}/user/login/request-fields.adoc[]
+include::{snippets}/user-docs-test/login/http-request.adoc[]
+include::{snippets}/user-docs-test/login/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/user/login/http-response.adoc[]
-include::{snippets}/user/login/response-fields.adoc[]
+include::{snippets}/user-docs-test/login/http-response.adoc[]
+include::{snippets}/user-docs-test/login/response-fields.adoc[]
 
 '''
 
 === 4. 로그아웃
 
 ==== Request
-include::{snippets}/user/logout/http-request.adoc[]
-include::{snippets}/user/logout/request-headers.adoc[]
+include::{snippets}/user-docs-test/logout/http-request.adoc[]
+include::{snippets}/user-docs-test/logout/request-headers.adoc[]
 
 ==== Response
-include::{snippets}/user/logout/http-response.adoc[]
+include::{snippets}/user-docs-test/logout/http-response.adoc[]
 
 '''
 
 === 5. 회원탈퇴
 
 ==== Request
-include::{snippets}/user/withdraw/http-request.adoc[]
-include::{snippets}/user/withdraw/request-headers.adoc[]
+include::{snippets}/user-docs-test/withdraw/http-request.adoc[]
+include::{snippets}/user-docs-test/withdraw/request-headers.adoc[]
 
 ==== Response
-include::{snippets}/user/withdraw/http-response.adoc[]
+include::{snippets}/user-docs-test/withdraw/http-response.adoc[]
 
 '''
 
@@ -110,24 +108,24 @@ include::{snippets}/user/withdraw/http-response.adoc[]
 - 행성에 메이트가 초대되었으면 메이트 정보도 함께 조회
 
 ==== Request
-include::{snippets}/user/find-me/http-request.adoc[]
-include::{snippets}/user/find-me/request-headers.adoc[]
+include::{snippets}/user-docs-test/find-me/http-request.adoc[]
+include::{snippets}/user-docs-test/find-me/request-headers.adoc[]
 
 ==== Response
-include::{snippets}/user/find-me/http-response.adoc[]
-include::{snippets}/user/find-me/response-fields.adoc[]
+include::{snippets}/user-docs-test/find-me/http-response.adoc[]
+include::{snippets}/user-docs-test/find-me/response-fields.adoc[]
 
 '''
 
 === 7. 닉네임 변경
 
 ==== Request
-include::{snippets}/user/update-name/http-request.adoc[]
-include::{snippets}/user/update-name/request-headers.adoc[]
-include::{snippets}/user/update-name/request-fields.adoc[]
+include::{snippets}/user-docs-test/update_name/http-request.adoc[]
+include::{snippets}/user-docs-test/update_name/request-headers.adoc[]
+include::{snippets}/user-docs-test/update_name/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/user/update-name/http-response.adoc[]
+include::{snippets}/user-docs-test/update_name/http-response.adoc[]
 
 '''
 
@@ -135,12 +133,12 @@ include::{snippets}/user/update-name/http-response.adoc[]
 === 8. 비밀번호 변경
 
 ==== Request
-include::{snippets}/user/update-password/http-request.adoc[]
-include::{snippets}/user/update-password/request-headers.adoc[]
-include::{snippets}/user/update-password/request-fields.adoc[]
+include::{snippets}/user-docs-test/update_password/http-request.adoc[]
+include::{snippets}/user-docs-test/update_password/request-headers.adoc[]
+include::{snippets}/user-docs-test/update_password/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/user/update-password/http-response.adoc[]
+include::{snippets}/user-docs-test/update_password/http-response.adoc[]
 
 '''
 
@@ -148,11 +146,11 @@ include::{snippets}/user/update-password/http-response.adoc[]
 - 임의의 비밀번호로 변경되고, 입력한 이메일로 메일 전송
 
 ==== Request
-include::{snippets}/user/reset-password/http-request.adoc[]
-include::{snippets}/user/reset-password/request-fields.adoc[]
+include::{snippets}/user-docs-test/reset_password/http-request.adoc[]
+include::{snippets}/user-docs-test/reset_password/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/user/reset-password/http-response.adoc[]
+include::{snippets}/user-docs-test/reset_password/http-response.adoc[]
 
 [[Planet]]
 == Planet
@@ -160,26 +158,26 @@ include::{snippets}/user/reset-password/http-response.adoc[]
 === 1. 행성 생성
 
 ==== Request
-include::{snippets}/planet/create/http-request.adoc[]
-include::{snippets}/planet/create/request-headers.adoc[]
-include::{snippets}/planet/create/request-fields.adoc[]
+include::{snippets}/planet-docs-test/create/http-request.adoc[]
+include::{snippets}/planet-docs-test/create/request-headers.adoc[]
+include::{snippets}/planet-docs-test/create/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/planet/create/http-response.adoc[]
-include::{snippets}/planet/create/response-fields.adoc[]
+include::{snippets}/planet-docs-test/create/http-response.adoc[]
+include::{snippets}/planet-docs-test/create/response-fields.adoc[]
 
 '''
 
 === 2. 초대코드 조회
 
 ==== Request
-include::{snippets}/planet/invite-code/http-request.adoc[]
-include::{snippets}/planet/invite-code/request-headers.adoc[]
-include::{snippets}/planet/invite-code/path-parameters.adoc[]
+include::{snippets}/planet-docs-test/get_invite_code/http-request.adoc[]
+include::{snippets}/planet-docs-test/get_invite_code/request-headers.adoc[]
+include::{snippets}/planet-docs-test/get_invite_code/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/planet/invite-code/http-response.adoc[]
-include::{snippets}/planet/invite-code/response-fields.adoc[]
+include::{snippets}/planet-docs-test/get_invite_code/http-response.adoc[]
+include::{snippets}/planet-docs-test/get_invite_code/response-fields.adoc[]
 
 '''
 
@@ -187,13 +185,13 @@ include::{snippets}/planet/invite-code/response-fields.adoc[]
 - 초대코드로 행성에 참가하기 전에 정보를 조회
 
 ==== Request
-include::{snippets}/planet/find-by-code/http-request.adoc[]
-include::{snippets}/planet/find-by-code/request-headers.adoc[]
-include::{snippets}/planet/find-by-code/request-parameters.adoc[]
+include::{snippets}/planet-docs-test/find_by_invite_code/http-request.adoc[]
+include::{snippets}/planet-docs-test/find_by_invite_code/request-headers.adoc[]
+include::{snippets}/planet-docs-test/find_by_invite_code/request-parameters.adoc[]
 
 ==== Response
-include::{snippets}/planet/find-by-code/http-response.adoc[]
-include::{snippets}/planet/find-by-code/response-fields.adoc[]
+include::{snippets}/planet-docs-test/find_by_invite_code/http-response.adoc[]
+include::{snippets}/planet-docs-test/find_by_invite_code/response-fields.adoc[]
 
 '''
 
@@ -202,47 +200,47 @@ include::{snippets}/planet/find-by-code/response-fields.adoc[]
 - 이미 행성에 2명이 참여해있다면 참가 불가
 
 ==== Request
-include::{snippets}/planet/join/http-request.adoc[]
-include::{snippets}/planet/join/request-headers.adoc[]
+include::{snippets}/planet-docs-test/join/http-request.adoc[]
+include::{snippets}/planet-docs-test/join/request-headers.adoc[]
 
 ==== Response
-include::{snippets}/planet/join/http-response.adoc[]
+include::{snippets}/planet-docs-test/join/http-response.adoc[]
 
 '''
 
 === 5. 행성 조회
 
 ==== Request
-include::{snippets}/planet/find/http-request.adoc[]
-include::{snippets}/planet/find/path-parameters.adoc[]
+include::{snippets}/planet-docs-test/find_by_id/http-request.adoc[]
+include::{snippets}/planet-docs-test/find_by_id/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/planet/find/http-response.adoc[]
-include::{snippets}/planet/find/response-fields.adoc[]
+include::{snippets}/planet-docs-test/find_by_id/http-response.adoc[]
+include::{snippets}/planet-docs-test/find_by_id/response-fields.adoc[]
 
 '''
 
 === 6. 이름으로 행성 조회
 
 ==== Request
-include::{snippets}/planet/find-list/http-request.adoc[]
-include::{snippets}/planet/find-list/request-parameters.adoc[]
+include::{snippets}/planet-docs-test/find_by_name/http-request.adoc[]
+include::{snippets}/planet-docs-test/find_by_name/request-parameters.adoc[]
 
 ==== Response
-include::{snippets}/planet/find-list/http-response.adoc[]
-include::{snippets}/planet/find-list/response-fields.adoc[]
+include::{snippets}/planet-docs-test/find_by_name/http-response.adoc[]
+include::{snippets}/planet-docs-test/find_by_name/response-fields.adoc[]
 
 '''
 
 === 7. 팔로우한 행성 조회
 
 ==== Request
-include::{snippets}/planet/follow-planets/http-request.adoc[]
-include::{snippets}/planet/follow-planets/request-parameters.adoc[]
+include::{snippets}/planet-docs-test/get_follow_planet/http-request.adoc[]
+include::{snippets}/planet-docs-test/get_follow_planet/request-parameters.adoc[]
 
 ==== Response
-include::{snippets}/planet/follow-planets/http-response.adoc[]
-include::{snippets}/planet/follow-planets/response-fields.adoc[]
+include::{snippets}/planet-docs-test/get_follow_planet/http-response.adoc[]
+include::{snippets}/planet-docs-test/get_follow_planet/response-fields.adoc[]
 
 '''
 
@@ -251,39 +249,39 @@ include::{snippets}/planet/follow-planets/response-fields.adoc[]
 - 다른 사람의 행성은 공개 코스만 조회
 
 ==== Request
-include::{snippets}/planet/courses/http-request.adoc[]
-include::{snippets}/planet/courses/request-headers.adoc[]
-include::{snippets}/planet/courses/request-parameters.adoc[]
-include::{snippets}/planet/courses/path-parameters.adoc[]
+include::{snippets}/planet-docs-test/find_planet_course/http-request.adoc[]
+include::{snippets}/planet-docs-test/find_planet_course/request-headers.adoc[]
+include::{snippets}/planet-docs-test/find_planet_course/request-parameters.adoc[]
+include::{snippets}/planet-docs-test/find_planet_course/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/planet/courses/http-response.adoc[]
-include::{snippets}/planet/courses/response-fields.adoc[]
+include::{snippets}/planet-docs-test/find_planet_course/http-response.adoc[]
+include::{snippets}/planet-docs-test/find_planet_course/response-fields.adoc[]
 
 '''
 
 === 9. 행성 수정
 
 ==== Request
-include::{snippets}/planet/update/http-request.adoc[]
-include::{snippets}/planet/update/request-headers.adoc[]
-include::{snippets}/planet/update/path-parameters.adoc[]
-include::{snippets}/planet/update/request-fields.adoc[]
+include::{snippets}/planet-docs-test/update/http-request.adoc[]
+include::{snippets}/planet-docs-test/update/request-headers.adoc[]
+include::{snippets}/planet-docs-test/update/path-parameters.adoc[]
+include::{snippets}/planet-docs-test/update/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/planet/update/http-response.adoc[]
+include::{snippets}/planet-docs-test/update/http-response.adoc[]
 
 '''
 
 === 10. 행성 삭제
 
 ==== Request
-include::{snippets}/planet/delete/http-request.adoc[]
-include::{snippets}/planet/delete/request-headers.adoc[]
-include::{snippets}/planet/delete/path-parameters.adoc[]
+include::{snippets}/planet-docs-test/remove/http-request.adoc[]
+include::{snippets}/planet-docs-test/remove/request-headers.adoc[]
+include::{snippets}/planet-docs-test/remove/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/planet/delete/http-response.adoc[]
+include::{snippets}/planet-docs-test/remove/http-response.adoc[]
 
 '''
 
@@ -291,22 +289,22 @@ include::{snippets}/planet/delete/http-response.adoc[]
 - 자신의 행성은 팔로우 불가
 
 ==== Request
-include::{snippets}/planet/follow/http-request.adoc[]
-include::{snippets}/planet/follow/request-headers.adoc[]
+include::{snippets}/planet-docs-test/follow/http-request.adoc[]
+include::{snippets}/planet-docs-test/follow/request-headers.adoc[]
 
 ==== Response
-include::{snippets}/planet/follow/http-response.adoc[]
+include::{snippets}/planet-docs-test/follow/http-response.adoc[]
 
 '''
 
 === 12. 행성 언팔로우
 
 ==== Request
-include::{snippets}/planet/unfollow/http-request.adoc[]
-include::{snippets}/planet/unfollow/request-headers.adoc[]
+include::{snippets}/planet-docs-test/unfollow/http-request.adoc[]
+include::{snippets}/planet-docs-test/unfollow/request-headers.adoc[]
 
 ==== Response
-include::{snippets}/planet/unfollow/http-response.adoc[]
+include::{snippets}/planet-docs-test/unfollow/http-response.adoc[]
 
 [[Course]]
 == Course
@@ -316,26 +314,26 @@ include::{snippets}/planet/unfollow/http-response.adoc[]
 - 왼쪽 아래를 원점으로 설정
 
 ==== Request
-include::{snippets}/course/create/http-request.adoc[]
-include::{snippets}/course/create/request-headers.adoc[]
-include::{snippets}/course/create/request-parts.adoc[]
-include::{snippets}/course/create/request-part-data-fields.adoc[]
+include::{snippets}/course-docs-test/create/http-request.adoc[]
+include::{snippets}/course-docs-test/create/request-headers.adoc[]
+include::{snippets}/course-docs-test/create/request-parts.adoc[]
+include::{snippets}/course-docs-test/create/request-part-data-fields.adoc[]
 
 ==== Response
-include::{snippets}/course/create/http-response.adoc[]
-include::{snippets}/course/create/response-fields.adoc[]
+include::{snippets}/course-docs-test/create/http-response.adoc[]
+include::{snippets}/course-docs-test/create/response-fields.adoc[]
 
-=== 2. 코스 조회
+=== 2. 아이디로 코스 조회
 - 다른 사람의 코스는 공개 코스만 조회 가능
 
 ==== Request
-include::{snippets}/course/find/http-request.adoc[]
-include::{snippets}/course/find/request-headers.adoc[]
-include::{snippets}/course/find/path-parameters.adoc[]
+include::{snippets}/course-docs-test/find_by_id/http-request.adoc[]
+include::{snippets}/course-docs-test/find_by_id/request-headers.adoc[]
+include::{snippets}/course-docs-test/find_by_id/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/course/find/http-response.adoc[]
-include::{snippets}/course/find/response-fields.adoc[]
+include::{snippets}/course-docs-test/find_by_id/http-response.adoc[]
+include::{snippets}/course-docs-test/find_by_id/response-fields.adoc[]
 
 '''
 
@@ -343,13 +341,13 @@ include::{snippets}/course/find/response-fields.adoc[]
 - 다른 사람의 코스는 공개 코스만, 내 코스는 비공개 코스도 조회
 
 ==== Request
-include::{snippets}/course/find-list/http-request.adoc[]
-include::{snippets}/course/find-list/request-headers.adoc[]
-include::{snippets}/course/find-list/request-parameters.adoc[]
+include::{snippets}/course-docs-test/find_by_name/http-request.adoc[]
+include::{snippets}/course-docs-test/find_by_name/request-headers.adoc[]
+include::{snippets}/course-docs-test/find_by_name/request-parameters.adoc[]
 
 ==== Response
-include::{snippets}/course/find-list/http-response.adoc[]
-include::{snippets}/course/find-list/response-fields.adoc[]
+include::{snippets}/course-docs-test/find_by_name/http-response.adoc[]
+include::{snippets}/course-docs-test/find_by_name/response-fields.adoc[]
 
 '''
 
@@ -357,13 +355,13 @@ include::{snippets}/course/find-list/response-fields.adoc[]
 - 내 모든 코스 + 다른 사람의 공개 코스를 최신순으로 조회
 
 ==== Request
-include::{snippets}/course/feed/http-request.adoc[]
-include::{snippets}/course/feed/request-headers.adoc[]
-include::{snippets}/course/feed/request-parameters.adoc[]
+include::{snippets}/course-docs-test/feed/http-request.adoc[]
+include::{snippets}/course-docs-test/feed/request-headers.adoc[]
+include::{snippets}/course-docs-test/feed/request-parameters.adoc[]
 
 ==== Response
-include::{snippets}/course/feed/http-response.adoc[]
-include::{snippets}/course/feed/response-fields.adoc[]
+include::{snippets}/course-docs-test/feed/http-response.adoc[]
+include::{snippets}/course-docs-test/feed/response-fields.adoc[]
 
 '''
 
@@ -372,27 +370,27 @@ include::{snippets}/course/feed/response-fields.adoc[]
 - 왼쪽 아래를 원점으로 설정
 
 ==== Request
-include::{snippets}/course/update/http-request.adoc[]
-include::{snippets}/course/update/request-headers.adoc[]
-include::{snippets}/course/update/path-parameters.adoc[]
-include::{snippets}/course/update/request-parts.adoc[]
-include::{snippets}/course/update/request-part-data-fields.adoc[]
+include::{snippets}/course-docs-test/update/http-request.adoc[]
+include::{snippets}/course-docs-test/update/request-headers.adoc[]
+include::{snippets}/course-docs-test/update/path-parameters.adoc[]
+include::{snippets}/course-docs-test/update/request-parts.adoc[]
+include::{snippets}/course-docs-test/update/request-part-data-fields.adoc[]
 
 ==== Response
-include::{snippets}/course/update/http-response.adoc[]
-include::{snippets}/course/update/response-fields.adoc[]
+include::{snippets}/course-docs-test/update/http-response.adoc[]
+include::{snippets}/course-docs-test/update/response-fields.adoc[]
 
 '''
 
 === 6. 코스 삭제
 
 ==== Request
-include::{snippets}/course/delete/http-request.adoc[]
-include::{snippets}/course/delete/request-headers.adoc[]
-include::{snippets}/course/delete/path-parameters.adoc[]
+include::{snippets}/course-docs-test/remove/http-request.adoc[]
+include::{snippets}/course-docs-test/remove/request-headers.adoc[]
+include::{snippets}/course-docs-test/remove/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/course/delete/http-response.adoc[]
+include::{snippets}/course-docs-test/remove/http-response.adoc[]
 
 '''
 
@@ -400,19 +398,71 @@ include::{snippets}/course/delete/http-response.adoc[]
 - 내 코스에도 좋아요 가능
 
 ==== Request
-include::{snippets}/course/like/http-request.adoc[]
-include::{snippets}/course/like/request-headers.adoc[]
-include::{snippets}/course/like/path-parameters.adoc[]
+include::{snippets}/course-docs-test/like/http-request.adoc[]
+include::{snippets}/course-docs-test/like/request-headers.adoc[]
+include::{snippets}/course-docs-test/like/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/course/like/http-response.adoc[]
+include::{snippets}/course-docs-test/like/http-response.adoc[]
 
 === 8. 코스 좋아요 취소
 
 ==== Request
-include::{snippets}/course/unlike/http-request.adoc[]
-include::{snippets}/course/unlike/request-headers.adoc[]
-include::{snippets}/course/unlike/path-parameters.adoc[]
+include::{snippets}/course-docs-test/unlike/http-request.adoc[]
+include::{snippets}/course-docs-test/unlike/request-headers.adoc[]
+include::{snippets}/course-docs-test/unlike/path-parameters.adoc[]
 
 ==== Response
-include::{snippets}/course/unlike/http-response.adoc[]
+include::{snippets}/course-docs-test/unlike/http-response.adoc[]
+
+[[Exceptions]]
+== Exceptions
+- 500번 오류 발생시 에러 ID와 함께 알려주세요
+
+|===
+|값|설명
+|id|에러 번호, 로그에서 에러 원인을 파악하는데 사용
+|code|에러 코드
+|message|에러 메세지
+|===
+
+=== 400 Bad Request
+|===
+|코드|설명
+|INVALID_INPUT|입력값이 잘못된 경우(주로 제약조건에 맞지 않는 경우)
+|INVALID_TYPE|입력값의 타입이 맞지 않는 경우(Number 자리에 String이 들어오는 경우, 존재하지 않는 Enum 값이 입력된 경우)
+|INVALID_JSON_FORMAT|JSON 입력값이 잘못된 경우
+|INVALID_PARAMETER|필수 파라미터가 입력되지 않은 경우
+|INVALID_HEADER|필수 헤더가 입력되지 않은 경우(주로 Content-Type이 잘못된 경우)
+|INPUT_SIZE_EXCEEDED|입력값이 크기를 초과한 경우(주로 이미지 사이즈 문제)
+|===
+
+=== 401 Unauthorized
+|===
+|코드|설명
+|AUTHENTICATION_FAILED|인증 실패(인증 토큰 오류)
+|NOT_AUTHENTICATED|로그인 상태가 아닌 경우
+|CERTIFICATION_FAILED|이메일 인증 실패
+|INVALID_PASSWORD|비밀번호 오류
+|===
+
+=== 403 Forbidden
+|===
+|코드|설명
+|NO_PERMISSION|권한 오류
+|SUSPENDED_USER|정지된 사용자가 로그인을 시도하는 경우
+|===
+
+=== 404 Not Found
+|===
+|코드|설명
+|NO_DATA|검색하는 데이터가 없는 경우(혹은 숨겨진 경우, HTTP 메서드가 잘못된 경우)
+|===
+
+=== 409 Conflict
+|===
+|코드|설명
+|DUPLICATED|중복 불가 제약조건을 위반하는 경우
+|PLANET_JOIN_FAILED|행성 참여 실패(내 행성에 참여, 이미 메이트가 들어온 행성에 참여)
+|PLANET_FOLLOW_FAILED|행성 팔로우 실패(내 행성 팔로우)
+|===

--- a/src/main/java/trying/cosmos/global/auth/AuthenticationInterceptor.java
+++ b/src/main/java/trying/cosmos/global/auth/AuthenticationInterceptor.java
@@ -51,7 +51,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         User user = userRepository.findByEmail(userData.get(SUBJECT_KEY)).orElseThrow(() -> new CustomException(ExceptionType.AUTHENTICATION_FAILED));
 
         if (!user.getStatus().equals(UserStatus.LOGIN)) {
-            throw new CustomException(ExceptionType.AUTHENTICATION_FAILED);
+            throw new CustomException(ExceptionType.NOT_AUTHENTICATED);
         }
 
         AuthKey.setKey(user.getId());

--- a/src/main/java/trying/cosmos/global/exception/CustomExceptionAdvice.java
+++ b/src/main/java/trying/cosmos/global/exception/CustomExceptionAdvice.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 
@@ -53,6 +54,12 @@ public class CustomExceptionAdvice {
         }
     }
 
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<CustomExceptionEntity> type(MethodArgumentTypeMismatchException e) {
+        return generalResponse(ExceptionType.INVALID_TYPE, e);
+    }
+
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<CustomExceptionEntity> parameter(MissingServletRequestParameterException e) {
         return generalResponse(ExceptionType.INVALID_PARAMETER, e);
@@ -65,7 +72,7 @@ public class CustomExceptionAdvice {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<CustomExceptionEntity> method(HttpRequestMethodNotSupportedException e) {
-        return generalResponse(ExceptionType.INVALID_METHOD, e);
+        return generalResponse(ExceptionType.NO_DATA, e);
     }
 
     @ExceptionHandler(NoSuchElementException.class)

--- a/src/main/java/trying/cosmos/global/exception/CustomExceptionEntity.java
+++ b/src/main/java/trying/cosmos/global/exception/CustomExceptionEntity.java
@@ -8,10 +8,12 @@ import trying.cosmos.global.aop.RequestKeyInterceptor;
 @Getter
 public class CustomExceptionEntity {
 
+    private final String id;
     private final String code;
     private final String message;
 
     public CustomExceptionEntity(ExceptionType eType, String message, Exception e) {
+        this.id = RequestKeyInterceptor.getRequestKey();
         this.code = eType.toString();
         this.message = message;
         log.info("[{}] Exception {}, {}", RequestKeyInterceptor.getRequestKey(), code, message, e);

--- a/src/test/java/trying/cosmos/docs/CertificationDocsTest.java
+++ b/src/test/java/trying/cosmos/docs/CertificationDocsTest.java
@@ -1,34 +1,47 @@
 package trying.cosmos.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import trying.cosmos.docs.utils.RestDocsConfiguration;
 import trying.cosmos.domain.certification.Certification;
 import trying.cosmos.domain.certification.CertificationRepository;
 import trying.cosmos.domain.certification.CertificationService;
 import trying.cosmos.domain.certification.request.CertificateRequest;
 import trying.cosmos.domain.certification.request.GenerateCertificationRequest;
 
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static trying.cosmos.docs.utils.ApiDocumentUtils.getDocumentRequest;
-import static trying.cosmos.docs.utils.ApiDocumentUtils.getDocumentResponse;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
+@Import(RestDocsConfiguration.class)
+@ExtendWith({RestDocumentationExtension.class})
 @Transactional
 @ActiveProfiles("test")
 public class CertificationDocsTest {
@@ -43,9 +56,22 @@ public class CertificationDocsTest {
     @Autowired
     CertificationRepository certificationRepository;
 
+    @Autowired
+    RestDocumentationResultHandler restDocs;
+
     private static final String JSON_CONTENT_TYPE = "application/json";
 
     private static final String EMAIL = "email@gmail.com";
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider, WebApplicationContext context){
+        this.mvc= MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .alwaysDo(restDocs)
+                .addFilters(new CharacterEncodingFilter("UTF-8",true))
+                .build();
+    }
 
     @Test
     @DisplayName("인증코드 생성")
@@ -53,17 +79,18 @@ public class CertificationDocsTest {
         String content = objectMapper.writeValueAsString(new GenerateCertificationRequest(EMAIL));
 
         ResultActions actions = mvc.perform(post("/certification")
-                .content(content)
-                .contentType(JSON_CONTENT_TYPE))
+                        .content(content)
+                        .contentType(JSON_CONTENT_TYPE))
                 .andExpect(status().isOk());
 
-        actions.andDo(document("certification/create-certification",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestFields(
-                                fieldWithPath("email").description("인증받으려는 이메일 주소")
-                        )
-                ));
+        actions.andDo(restDocs.document(
+                requestFields(
+                        fieldWithPath("email")
+                                .type(STRING)
+                                .description("인증받으려는 이메일 주소")
+                                .attributes(key("constraint").value("이메일 형식"))
+                )
+        ));
     }
 
     @Test
@@ -74,17 +101,22 @@ public class CertificationDocsTest {
         String content = objectMapper.writeValueAsString(new CertificateRequest(EMAIL, certification.getCode()));
 
         ResultActions actions = mvc.perform(patch("/certification")
-                .content(content)
-                .contentType(JSON_CONTENT_TYPE))
+                        .content(content)
+                        .contentType(JSON_CONTENT_TYPE))
                 .andExpect(status().isOk());
 
-        actions.andDo(document("certification/certificate",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestFields(
-                                fieldWithPath("email").description("인증받으려는 이메일 주소"),
-                                fieldWithPath("code").description("이메일로 받은 인증 코드")
-                        )
-                ));
+        actions.andDo(restDocs.document(
+                requestFields(
+                        fieldWithPath("email")
+                                .type(STRING)
+                                .description("인증받으려는 이메일 주소")
+                                .attributes(key("constraint").value("이메일 형식")),
+                        fieldWithPath("code")
+                                .type(STRING)
+                                .description("이메일로 받은 인증 코드")
+                )
+        ));
     }
 }
+
+

--- a/src/test/java/trying/cosmos/docs/CourseDocsTest.java
+++ b/src/test/java/trying/cosmos/docs/CourseDocsTest.java
@@ -1,20 +1,32 @@
 package trying.cosmos.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockPart;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import trying.cosmos.docs.utils.RestDocsConfiguration;
 import trying.cosmos.domain.course.Access;
 import trying.cosmos.domain.course.Course;
 import trying.cosmos.domain.course.CourseService;
@@ -37,17 +49,19 @@ import java.util.List;
 
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static trying.cosmos.docs.utils.ApiDocumentUtils.getDocumentRequest;
-import static trying.cosmos.docs.utils.ApiDocumentUtils.getDocumentResponse;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
+@Import(RestDocsConfiguration.class)
+@ExtendWith({RestDocumentationExtension.class})
 @Transactional
 @ActiveProfiles("test")
 public class CourseDocsTest {
@@ -65,6 +79,9 @@ public class CourseDocsTest {
     @Autowired
     CourseService courseService;
 
+    @Autowired
+    RestDocumentationResultHandler restDocs;
+
     private static final String JSON_CONTENT_TYPE = "application/json";
 
     private static final String EMAIL = "email@gmail.com";
@@ -75,7 +92,15 @@ public class CourseDocsTest {
     private static final String TITLE = "효자시장 맛집코스";
     private static final String BODY = "굿";
 
-    private static final String IMAGE_PATH = "src/test/resources/image.png";
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider, WebApplicationContext context){
+        this.mvc= MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .alwaysDo(restDocs)
+                .addFilters(new CharacterEncodingFilter("UTF-8",true))
+                .build();
+    }
 
     @Test
     @DisplayName("코스 생성")
@@ -103,39 +128,62 @@ public class CourseDocsTest {
                 .header("accessToken", accessToken))
                 .andExpect(status().isOk());
 
-        actions.andDo(document("course/create",
-                getDocumentRequest(),
-                getDocumentResponse(),
+        actions.andDo(restDocs.document(
                 requestHeaders(
-                        headerWithName("accessToken").description("인증 토큰")
+                        headerWithName("accessToken")
+                                .description("인증 토큰")
                 ),
                 requestPartFields("data",
-                        fieldWithPath("planetId").description("코스를 만들 행성 id"),
-                        fieldWithPath("title").description("코스 제목"),
-                        fieldWithPath("body").description("코스 본문"),
-                        fieldWithPath("access").description("코스 공개여부"),
-                        fieldWithPath("tags[].place.placeId").description("태그할 장소 번호(지도 API에서 제공하는 ID)"),
-                        fieldWithPath("tags[].place.name").description("태그할 장소 이름"),
-                        fieldWithPath("tags[].place.latitude").description("태그할 장소 위도"),
-                        fieldWithPath("tags[].place.longitude").description("태그할 장소 경도"),
-                        fieldWithPath("tags[].name").description("태그 이름")
+                        fieldWithPath("planetId")
+                                .type(NUMBER)
+                                .description("코스를 만들 행성 id"),
+                        fieldWithPath("title")
+                                .type(STRING)
+                                .description("코스 제목"),
+                        fieldWithPath("body")
+                                .type(STRING)
+                                .description("코스 본문"),
+                        fieldWithPath("access")
+                                .type(STRING)
+                                .description("코스 공개여부"),
+                        fieldWithPath("tags[].place.placeId")
+                                .type(NUMBER)
+                                .description("태그할 장소 번호(지도 API에서 제공하는 ID)"),
+                        fieldWithPath("tags[].place.name")
+                                .type(STRING)
+                                .description("태그할 장소 이름"),
+                        fieldWithPath("tags[].place.latitude")
+                                .type(NUMBER)
+                                .description("태그할 장소 위도"),
+                        fieldWithPath("tags[].place.longitude")
+                                .type(NUMBER)
+                                .description("태그할 장소 경도"),
+                        fieldWithPath("tags[].name")
+                                .type(STRING)
+                                .description("태그 이름")
                 ),
                 requestParts(
-                        partWithName("data").description("코스 생성을 위한 데이터"),
-                        partWithName("images").description("업로드할 이미지 목록")
+                        partWithName("data")
+                                .description("코스 생성을 위한 데이터"),
+                        partWithName("images")
+                                .description("업로드할 이미지 목록")
                 ),
                 responseFields(
-                        fieldWithPath("courseId").description("만들어진 코스 id"),
-                        fieldWithPath("stars").description("별자리 이미지에서 별 좌표"),
-                        fieldWithPath("stars[].x").description("x좌표(경도)"),
-                        fieldWithPath("stars[].y").description("y좌표(위도)")
+                        fieldWithPath("courseId")
+                                .description("만들어진 코스 id"),
+                        fieldWithPath("stars")
+                                .description("별자리 이미지에서 별 좌표"),
+                        fieldWithPath("stars[].x")
+                                .description("x좌표(경도)"),
+                        fieldWithPath("stars[].y")
+                                .description("y좌표(위도)")
                 )
         ));
     }
 
     @Test
     @DisplayName("아이디로 코스 조회")
-    void find() throws Exception {
+    void find_by_id() throws Exception {
         User user = userRepository.save(new User(EMAIL, PASSWORD, NAME, UserStatus.LOGOUT, Authority.USER));
         String accessToken = userService.login(EMAIL, PASSWORD, DEVICE_TOKEN);
 
@@ -153,37 +201,52 @@ public class CourseDocsTest {
                 .contentType(JSON_CONTENT_TYPE))
                 .andExpect(status().isOk());
 
-        actions.andDo(document("course/find",
-                getDocumentRequest(),
-                getDocumentResponse(),
+        actions.andDo(restDocs.document(
                 requestHeaders(
-                        headerWithName("accessToken").description("인증 토큰")
+                        headerWithName("accessToken")
+                                .description("인증 토큰")
                 ),
                 pathParameters(
-                        parameterWithName("courseId").description("코스 id")
+                        parameterWithName("courseId")
+                                .description("코스 id")
+                                .attributes(key("type").value("Number"))
                 ),
                 responseFields(
-                        fieldWithPath("title").description("코스 제목"),
-                        fieldWithPath("body").description("코스 본문"),
-                        fieldWithPath("createdDate").description("코스 생성일"),
-                        fieldWithPath("liked").description("코스 좋아요 여부"),
-                        fieldWithPath("planet.planetId").description("코스가 포함된 행성 id"),
-                        fieldWithPath("planet.name").description("코스가 포함된 행성 이름"),
-                        fieldWithPath("planet.image").description("코스가 포함된 행성 이미지 타입"),
-                        fieldWithPath("planet.dday").description("코스가 포함된 행성 dday"),
-                        fieldWithPath("tags[].place.placeNumber").description("태그할 장소 번호(지도 API에서 제공하는 ID)"),
-                        fieldWithPath("tags[].place.name").description("태그할 장소 이름"),
-                        fieldWithPath("tags[].place.coordinate.latitude").description("태그할 장소 위도"),
-                        fieldWithPath("tags[].place.coordinate.longitude").description("태그할 장소 경도"),
-                        fieldWithPath("tags[].name").description("태그 이름"),
-                        fieldWithPath("images[]").description("이미지 이름")
+                        fieldWithPath("title")
+                                .description("코스 제목"),
+                        fieldWithPath("body")
+                                .description("코스 본문"),
+                        fieldWithPath("createdDate")
+                                .description("코스 생성일"),
+                        fieldWithPath("liked")
+                                .description("코스 좋아요 여부"),
+                        fieldWithPath("planet.planetId")
+                                .description("코스가 포함된 행성 id"),
+                        fieldWithPath("planet.name")
+                                .description("코스가 포함된 행성 이름"),
+                        fieldWithPath("planet.image")
+                                .description("코스가 포함된 행성 이미지 타입"),
+                        fieldWithPath("planet.dday")
+                                .description("코스가 포함된 행성 dday"),
+                        fieldWithPath("tags[].place.placeNumber")
+                                .description("태그할 장소 번호(지도 API에서 제공하는 ID)"),
+                        fieldWithPath("tags[].place.name")
+                                .description("태그할 장소 이름"),
+                        fieldWithPath("tags[].place.coordinate.latitude")
+                                .description("태그할 장소 위도"),
+                        fieldWithPath("tags[].place.coordinate.longitude")
+                                .description("태그할 장소 경도"),
+                        fieldWithPath("tags[].name")
+                                .description("태그 이름"),
+                        fieldWithPath("images[]")
+                                .description("이미지 이름")
                 )
         ));
     }
 
     @Test
     @DisplayName("이름으로 코스 조회")
-    void find_list() throws Exception {
+    void find_by_name() throws Exception {
         User user = userRepository.save(new User(EMAIL, PASSWORD, NAME, UserStatus.LOGOUT, Authority.USER));
         String accessToken = userService.login(EMAIL, PASSWORD, DEVICE_TOKEN);
 
@@ -209,36 +272,55 @@ public class CourseDocsTest {
                 .contentType(JSON_CONTENT_TYPE))
                 .andExpect(status().isOk());
 
-        actions.andDo(document("course/find-list",
-                getDocumentRequest(),
-                getDocumentResponse(),
+        actions.andDo(restDocs.document(
                 requestHeaders(
-                        headerWithName("accessToken").description("인증 토큰")
+                        headerWithName("accessToken")
+                                .description("인증 토큰")
                 ),
                 requestParameters(
-                        parameterWithName("query").description("검색어(제목)").optional(),
-                        parameterWithName("page").description("페이지 번호").optional(),
-                        parameterWithName("size").description("한 페이지 크기").optional()
+                        parameterWithName("query")
+                                .description("검색어(제목)")
+                                .attributes(key("type").value("String"))
+                                .optional(),
+                        parameterWithName("page")
+                                .description("페이지 번호")
+                                .attributes(key("type").value("Number"))
+                                .optional(),
+                        parameterWithName("size")
+                                .description("한 페이지 크기")
+                                .attributes(key("type").value("Number"))
+                                .optional()
                 ),
                 responseFields(
-                        fieldWithPath("courses[].courseId").description("코스 id"),
-                        fieldWithPath("courses[].planet.planetId").description("코스가 포함된 행성 id"),
-                        fieldWithPath("courses[].planet.name").description("코스가 포함된 행성 이름"),
-                        fieldWithPath("courses[].planet.image").description("코스가 포함된 행성 이미지 타입"),
-                        fieldWithPath("courses[].planet.dday").description("코스가 포함된 행성 dday"),
-                        fieldWithPath("courses[].title").description("코스 제목"),
-                        fieldWithPath("courses[].createdDate").description("코스 생성일"),
-                        fieldWithPath("courses[].liked").description("코스 좋아요 여부"),
-                        fieldWithPath("courses[].images[]").description("이미지 이름"),
-                        fieldWithPath("size").description("불러온 코스 수"),
-                        fieldWithPath("hasNext").description("다음 페이지 존재 여부")
+                        fieldWithPath("courses[].courseId")
+                                .description("코스 id"),
+                        fieldWithPath("courses[].planet.planetId")
+                                .description("코스가 포함된 행성 id"),
+                        fieldWithPath("courses[].planet.name")
+                                .description("코스가 포함된 행성 이름"),
+                        fieldWithPath("courses[].planet.image")
+                                .description("코스가 포함된 행성 이미지 타입"),
+                        fieldWithPath("courses[].planet.dday")
+                                .description("코스가 포함된 행성 dday"),
+                        fieldWithPath("courses[].title")
+                                .description("코스 제목"),
+                        fieldWithPath("courses[].createdDate")
+                                .description("코스 생성일"),
+                        fieldWithPath("courses[].liked")
+                                .description("코스 좋아요 여부"),
+                        fieldWithPath("courses[].images[]")
+                                .description("이미지 이름"),
+                        fieldWithPath("size")
+                                .description("불러온 코스 수"),
+                        fieldWithPath("hasNext")
+                                .description("다음 페이지 존재 여부")
                 )
         ));
     }
 
     @Test
     @DisplayName("피드 조회")
-    void get_feed() throws Exception {
+    void feed() throws Exception {
         User user = userRepository.save(new User(EMAIL, PASSWORD, NAME, UserStatus.LOGOUT, Authority.USER));
         User follow = userRepository.save(new User("follow@gmail.com", PASSWORD, "follow", UserStatus.LOGOUT, Authority.USER));
         String accessToken = userService.login(EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -265,28 +347,44 @@ public class CourseDocsTest {
                 .contentType(JSON_CONTENT_TYPE))
                 .andExpect(status().isOk());
 
-        actions.andDo(document("course/feed",
-                getDocumentRequest(),
-                getDocumentResponse(),
+        actions.andDo(restDocs.document(
                 requestHeaders(
-                        headerWithName("accessToken").description("인증 토큰")
+                        headerWithName("accessToken")
+                                .description("인증 토큰")
                 ),
                 requestParameters(
-                        parameterWithName("page").description("페이지 번호").optional(),
-                        parameterWithName("size").description("한 페이지 크기").optional()
+                        parameterWithName("page")
+                                .description("페이지 번호")
+                                .attributes(key("type").value("Number"))
+                                .optional(),
+                        parameterWithName("size")
+                                .description("한 페이지 크기")
+                                .attributes(key("type").value("Number"))
+                                .optional()
                 ),
                 responseFields(
-                        fieldWithPath("courses[].courseId").description("코스 id"),
-                        fieldWithPath("courses[].planet.planetId").description("코스가 포함된 행성 id"),
-                        fieldWithPath("courses[].planet.name").description("코스가 포함된 행성 이름"),
-                        fieldWithPath("courses[].planet.image").description("코스가 포함된 행성 이미지 타입"),
-                        fieldWithPath("courses[].planet.dday").description("코스가 포함된 행성 dday"),
-                        fieldWithPath("courses[].title").description("코스 제목"),
-                        fieldWithPath("courses[].createdDate").description("코스 생성일"),
-                        fieldWithPath("courses[].liked").description("코스 좋아요 여부"),
-                        fieldWithPath("courses[].images[]").description("이미지 이름"),
-                        fieldWithPath("size").description("불러온 코스 수"),
-                        fieldWithPath("hasNext").description("다음 페이지 존재 여부")
+                        fieldWithPath("courses[].courseId")
+                                .description("코스 id"),
+                        fieldWithPath("courses[].planet.planetId")
+                                .description("코스가 포함된 행성 id"),
+                        fieldWithPath("courses[].planet.name")
+                                .description("코스가 포함된 행성 이름"),
+                        fieldWithPath("courses[].planet.image")
+                                .description("코스가 포함된 행성 이미지 타입"),
+                        fieldWithPath("courses[].planet.dday")
+                                .description("코스가 포함된 행성 dday"),
+                        fieldWithPath("courses[].title")
+                                .description("코스 제목"),
+                        fieldWithPath("courses[].createdDate")
+                                .description("코스 생성일"),
+                        fieldWithPath("courses[].liked")
+                                .description("코스 좋아요 여부"),
+                        fieldWithPath("courses[].images[]")
+                                .description("이미지 이름"),
+                        fieldWithPath("size")
+                                .description("불러온 코스 수"),
+                        fieldWithPath("hasNext")
+                                .description("다음 페이지 존재 여부")
                 )
         ));
     }
@@ -325,34 +423,57 @@ public class CourseDocsTest {
                 .header("accessToken", accessToken)
         ).andExpect(status().isOk());
 
-        actions.andDo(document("course/update",
-                getDocumentRequest(),
-                getDocumentResponse(),
+        actions.andDo(restDocs.document(
                 requestHeaders(
-                        headerWithName("accessToken").description("인증 토큰")
+                        headerWithName("accessToken")
+                                .description("인증 토큰")
                 ),
                 pathParameters(
-                        parameterWithName("courseId").description("코스 id")
+                        parameterWithName("courseId")
+                                .description("코스 id")
+                                .attributes(key("type").value("Number"))
                 ),
                 requestPartFields("data",
-                        fieldWithPath("title").description("코스 제목"),
-                        fieldWithPath("body").description("코스 본문"),
-                        fieldWithPath("access").description("코스 공개여부"),
-                        fieldWithPath("tags[].place.placeId").description("태그할 장소 번호(지도 API에서 제공하는 ID)"),
-                        fieldWithPath("tags[].place.name").description("태그할 장소 이름"),
-                        fieldWithPath("tags[].place.latitude").description("태그할 장소 위도"),
-                        fieldWithPath("tags[].place.longitude").description("태그할 장소 경도"),
-                        fieldWithPath("tags[].name").description("태그 이름")
+                        fieldWithPath("title")
+                                .type(STRING)
+                                .description("코스 제목"),
+                        fieldWithPath("body")
+                                .type(STRING)
+                                .description("코스 본문"),
+                        fieldWithPath("access")
+                                .type(STRING)
+                                .description("코스 공개여부"),
+                        fieldWithPath("tags[].place.placeId")
+                                .type(NUMBER)
+                                .description("태그할 장소 번호(지도 API에서 제공하는 ID)"),
+                        fieldWithPath("tags[].place.name")
+                                .type(STRING)
+                                .description("태그할 장소 이름"),
+                        fieldWithPath("tags[].place.latitude")
+                                .type(NUMBER)
+                                .description("태그할 장소 위도"),
+                        fieldWithPath("tags[].place.longitude")
+                                .type(NUMBER)
+                                .description("태그할 장소 경도"),
+                        fieldWithPath("tags[].name")
+                                .type(STRING)
+                                .description("태그 이름")
                 ),
                 requestParts(
-                        partWithName("data").description("코스 생성을 위한 데이터"),
-                        partWithName("images").description("업로드할 이미지 목록")
+                        partWithName("data")
+                                .description("코스 생성을 위한 데이터"),
+                        partWithName("images")
+                                .description("업로드할 이미지 목록")
                 ),
                 responseFields(
-                        fieldWithPath("courseId").description("만들어진 코스 id"),
-                        fieldWithPath("stars").description("별자리 이미지에서 별 좌표"),
-                        fieldWithPath("stars[].x").description("x좌표(경도)"),
-                        fieldWithPath("stars[].y").description("y좌표(위도)")
+                        fieldWithPath("courseId")
+                                .description("만들어진 코스 id"),
+                        fieldWithPath("stars")
+                                .description("별자리 이미지에서 별 좌표"),
+                        fieldWithPath("stars[].x")
+                                .description("x좌표(경도)"),
+                        fieldWithPath("stars[].y")
+                                .description("y좌표(위도)")
                 )
         ));
     }
@@ -377,17 +498,20 @@ public class CourseDocsTest {
                 .contentType(JSON_CONTENT_TYPE)
         ).andExpect(status().isOk());
 
-        actions.andDo(document("course/delete",
-                getDocumentRequest(),
-                getDocumentResponse(),
+        actions.andDo(restDocs.document(
                 requestHeaders(
-                        headerWithName("accessToken").description("인증 토큰")
+                        headerWithName("accessToken")
+                                .description("인증 토큰")
                 ),
                 pathParameters(
-                        parameterWithName("courseId").description("코스 id")
+                        parameterWithName("courseId")
+                                .description("코스 id")
+                                .attributes(key("type").value("Number"))
                 ),
                 pathParameters(
-                        parameterWithName("courseId").description("코스 id")
+                        parameterWithName("courseId")
+                                .description("코스 id")
+                                .attributes(key("type").value("Number"))
                 )
         ));
     }
@@ -412,14 +536,15 @@ public class CourseDocsTest {
                 .contentType(JSON_CONTENT_TYPE))
                 .andExpect(status().isOk());
 
-        actions.andDo(document("course/like",
-                getDocumentRequest(),
-                getDocumentResponse(),
+        actions.andDo(restDocs.document(
                 requestHeaders(
-                        headerWithName("accessToken").description("인증 토큰")
+                        headerWithName("accessToken")
+                                .description("인증 토큰")
                 ),
                 pathParameters(
-                        parameterWithName("courseId").description("코스 id")
+                        parameterWithName("courseId")
+                                .description("코스 id")
+                                .attributes(key("type").value("Number"))
                 )
         ));
     }
@@ -446,14 +571,15 @@ public class CourseDocsTest {
                 .contentType(JSON_CONTENT_TYPE))
                 .andExpect(status().isOk());
 
-        actions.andDo(document("course/unlike",
-                getDocumentRequest(),
-                getDocumentResponse(),
+        actions.andDo(restDocs.document(
                 requestHeaders(
-                        headerWithName("accessToken").description("인증 토큰")
+                        headerWithName("accessToken")
+                                .description("인증 토큰")
                 ),
                 pathParameters(
-                        parameterWithName("courseId").description("코스 id")
+                        parameterWithName("courseId")
+                                .description("코스 id")
+                                .attributes(key("type").value("Number"))
                 )
         ));
     }

--- a/src/test/java/trying/cosmos/docs/utils/RestDocsConfiguration.java
+++ b/src/test/java/trying/cosmos/docs/utils/RestDocsConfiguration.java
@@ -1,0 +1,25 @@
+package trying.cosmos.docs.utils;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+@TestConfiguration
+public class RestDocsConfiguration {
+    @Bean
+    public RestDocumentationResultHandler restDocsMockMvcConfigurationCustomizer() {
+        return MockMvcRestDocumentation.document("{class-name}/{method-name}",
+                Preprocessors.preprocessRequest(
+                        modifyUris()
+                                .scheme("http")
+                                .host("15.165.72.196")
+                                .port(3059),
+                        prettyPrint()
+                ),
+                preprocessResponse(prettyPrint()));
+    }
+}

--- a/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,0 +1,12 @@
+==== Path Variable +{{path}}+
+|===
+|값|타입|설명|필수값
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{type}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,13 @@
+==== Request Fields
+|===
+|값|타입|설명|필수값|제약조건
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraint}}{{.}}{{/constraint}}{{/tableCellContent}}
+
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-headers.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-headers.snippet
@@ -1,0 +1,10 @@
+==== Request Headers
+|===
+|값|설명
+
+{{#headers}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/headers}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
@@ -1,0 +1,13 @@
+==== Request Parameters
+|===
+|값|타입|설명|필수값|제약조건
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{type}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraint}}{{.}}{{/constraint}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-part-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-part-fields.snippet
@@ -1,0 +1,13 @@
+==== Request Fields
+|===
+|값|타입|설명|필수값|제약조건
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraint}}{{.}}{{/constraint}}{{/tableCellContent}}
+
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-parts.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parts.snippet
@@ -1,0 +1,10 @@
+==== Multipart Request
+|===
+|값|설명
+
+{{#requestParts}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/requestParts}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,11 @@
+==== Response Fields
+|===
+|값|타입|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
## 🔍 Issue
- Close #35

## 📝 Task
- Request에 필요한 타입, 필수값 여부 등과 같은 정보를 위해 커스텀 snippet 제작

## 🧐 Reference
- [Springboot restdocs 적용기[2] 실전 사용](https://dingdingmin-back-end-developer.tistory.com/entry/Springboot-restdocs-%EC%A0%81%EC%9A%A9%EA%B8%B02-%EC%8B%A4%EC%A0%84-%EC%82%AC%EC%9A%A9?category=904391)
- [Spring Rest Docs 적용](https://techblog.woowahan.com/2597/)
- [Spring Rest Docs로 API 문서화하기](https://os94.tistory.com/199)
- [Spring REST Docs(5) - 문서조각 커스텀](https://dotheright.tistory.com/339)
- [Spring REST Docs 살펴볼만한 기능들](https://velog.io/@dae-hwa/Spring-REST-Docs-%EC%82%B4%ED%8E%B4%EB%B3%BC%EB%A7%8C%ED%95%9C-%EA%B8%B0%EB%8A%A5%EB%93%A4)
- [AsciiDoc Syntax Quick Reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)
- [mustache의 사용법 간단 정리](https://engineer-mole.tistory.com/123)
