### PR TITLE
[Feature] #48 : In-memory 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 
 	// S3
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.322'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/trying/cosmos/domain/course/controller/CourseController.java
+++ b/src/main/java/trying/cosmos/domain/course/controller/CourseController.java
@@ -12,9 +12,9 @@ import trying.cosmos.domain.course.dto.response.CourseCreateResponse;
 import trying.cosmos.domain.course.dto.response.CourseFindResponse;
 import trying.cosmos.domain.course.dto.response.CourseListFindResponse;
 import trying.cosmos.domain.course.service.CourseService;
-import trying.cosmos.global.auth.AuthKey;
-import trying.cosmos.global.auth.Authority;
 import trying.cosmos.global.auth.AuthorityOf;
+import trying.cosmos.global.auth.entity.AuthKey;
+import trying.cosmos.global.auth.entity.Authority;
 
 import java.util.List;
 

--- a/src/main/java/trying/cosmos/domain/planet/controller/PlanetController.java
+++ b/src/main/java/trying/cosmos/domain/planet/controller/PlanetController.java
@@ -8,9 +8,9 @@ import trying.cosmos.domain.planet.dto.request.PlanetUpdateRequest;
 import trying.cosmos.domain.planet.dto.response.*;
 import trying.cosmos.domain.planet.entity.Planet;
 import trying.cosmos.domain.planet.service.PlanetService;
-import trying.cosmos.global.auth.AuthKey;
-import trying.cosmos.global.auth.Authority;
 import trying.cosmos.global.auth.AuthorityOf;
+import trying.cosmos.global.auth.entity.AuthKey;
+import trying.cosmos.global.auth.entity.Authority;
 
 @RestController
 @RequestMapping("/planets")

--- a/src/main/java/trying/cosmos/domain/user/controller/UserController.java
+++ b/src/main/java/trying/cosmos/domain/user/controller/UserController.java
@@ -9,10 +9,10 @@ import trying.cosmos.domain.user.dto.response.UserEmailExistResponse;
 import trying.cosmos.domain.user.dto.response.UserFindResponse;
 import trying.cosmos.domain.user.dto.response.UserLoginResponse;
 import trying.cosmos.domain.user.service.UserService;
-import trying.cosmos.global.auth.AuthKey;
 import trying.cosmos.global.auth.AuthorityOf;
+import trying.cosmos.global.auth.entity.AuthKey;
 
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 
 @RestController
 @RequestMapping("/users")

--- a/src/main/java/trying/cosmos/domain/user/entity/User.java
+++ b/src/main/java/trying/cosmos/domain/user/entity/User.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import org.apache.commons.lang3.RandomStringUtils;
 import trying.cosmos.domain.common.DateAuditingEntity;
 import trying.cosmos.domain.planet.entity.Planet;
-import trying.cosmos.global.auth.Authority;
+import trying.cosmos.global.auth.entity.Authority;
 import trying.cosmos.global.exception.CustomException;
 import trying.cosmos.global.exception.ExceptionType;
 import trying.cosmos.global.utils.cipher.BCryptUtils;

--- a/src/main/java/trying/cosmos/domain/user/service/UserService.java
+++ b/src/main/java/trying/cosmos/domain/user/service/UserService.java
@@ -8,6 +8,8 @@ import trying.cosmos.domain.certification.repository.CertificationRepository;
 import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.domain.user.repository.UserRepository;
 import trying.cosmos.global.auth.TokenProvider;
+import trying.cosmos.global.auth.entity.Session;
+import trying.cosmos.global.auth.repository.SessionRepository;
 import trying.cosmos.global.exception.CustomException;
 import trying.cosmos.global.exception.ExceptionType;
 import trying.cosmos.global.utils.cipher.BCryptUtils;
@@ -25,6 +27,7 @@ import static org.apache.commons.lang3.RandomStringUtils.random;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final SessionRepository sessionRepository;
     private final CertificationRepository certificationRepository;
 
     private final EmailUtils emailUtils;
@@ -49,7 +52,8 @@ public class UserService {
     public String login(String email, String password, String deviceToken) {
         User user = userRepository.findByEmail(email).orElseThrow();
         user.login(password, deviceToken);
-        return tokenProvider.getAccessToken(user);
+        Session auth = sessionRepository.save(new Session(user));
+        return tokenProvider.getAccessToken(auth);
     }
 
     public User find(Long userId) {
@@ -89,12 +93,14 @@ public class UserService {
     @Transactional
     public void logout(Long userId) {
         User user = userRepository.findById(userId).orElseThrow();
+        sessionRepository.findByUserId(userId).ifPresent(sessionRepository::delete);
         user.logout();
     }
 
     @Transactional
     public void withdraw(Long userId) {
         User user = userRepository.findById(userId).orElseThrow();
+        sessionRepository.findByUserId(userId).ifPresent(sessionRepository::delete);
         user.withdraw();
     }
 }

--- a/src/main/java/trying/cosmos/global/aop/AuthenticationLogInterceptor.java
+++ b/src/main/java/trying/cosmos/global/aop/AuthenticationLogInterceptor.java
@@ -6,15 +6,14 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static trying.cosmos.global.auth.AuthKey.*;
+import static trying.cosmos.global.auth.entity.AuthKey.*;
 
 @Slf4j
 public class AuthenticationLogInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-//        log.debug("");
-        log.debug("[Authentication Info]");
+        log.debug("[Session Info]");
         log.debug("");
         getAuthenticationInfoLog();
         log.debug("");
@@ -27,7 +26,7 @@ public class AuthenticationLogInterceptor implements HandlerInterceptor {
         log.debug("- Need Authenticate: {}", needAuthenticate());
         log.debug("- Is Authenticated: {}", isAuthenticated());
         if (needAuthenticate() && isAuthenticated()) {
-            log.debug("- Authentication Key: {}", getKey());
+            log.debug("- Session Key: {}", getKey());
         }
     }
 }

--- a/src/main/java/trying/cosmos/global/aop/MethodLoggerAspect.java
+++ b/src/main/java/trying/cosmos/global/aop/MethodLoggerAspect.java
@@ -25,7 +25,7 @@ public class MethodLoggerAspect {
         }
         Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
         for (int i = 0; i < method.getParameters().length; i++) {
-            log.trace("{}- {}: {}", LogSpace.getSpace(), method.getParameters()[i].getName(), joinPoint.getArgs()[i].toString());
+            log.trace("{}- {}: {}", LogSpace.getSpace(), method.getParameters()[i].getName(), joinPoint.getArgs()[i]);
         }
 
         long startTime = System.currentTimeMillis();

--- a/src/main/java/trying/cosmos/global/aop/Pointcuts.java
+++ b/src/main/java/trying/cosmos/global/aop/Pointcuts.java
@@ -19,6 +19,6 @@ public class Pointcuts {
     @Pointcut("execution(* trying.cosmos.global.utils..*(..))")
     public void utilsObject() {}
 
-    @Pointcut("domainObject() || authObject() || devObject() || utilsObject()")
+    @Pointcut("domainObject() || devObject() || utilsObject()")
     public void methodLogObject() {}
 }

--- a/src/main/java/trying/cosmos/global/auth/AuthUtils.java
+++ b/src/main/java/trying/cosmos/global/auth/AuthUtils.java
@@ -1,0 +1,40 @@
+package trying.cosmos.global.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import trying.cosmos.domain.user.entity.UserStatus;
+import trying.cosmos.global.auth.entity.Session;
+import trying.cosmos.global.auth.repository.SessionRepository;
+import trying.cosmos.global.exception.CustomException;
+import trying.cosmos.global.exception.ExceptionType;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUtils {
+
+    private static final String ACCESS_TOKEN_HEADER = "accessToken";
+
+    private final SessionRepository sessionRepository;
+    private final TokenProvider tokenProvider;
+
+    public Session checkAuthenticate(HttpServletRequest request) {
+        String token = request.getHeader(ACCESS_TOKEN_HEADER);
+        if (token == null || !tokenProvider.validateToken(token)) {
+            throw new CustomException(ExceptionType.AUTHENTICATION_FAILED);
+        }
+
+        Optional<Session> optionalAuth = sessionRepository.findById(tokenProvider.getSubject(token));
+        if (optionalAuth.isEmpty()) {
+            throw new CustomException(ExceptionType.NOT_AUTHENTICATED);
+        }
+        Session auth = optionalAuth.get();
+
+        if (!auth.getStatus().equals(UserStatus.LOGIN)) {
+            throw new CustomException(ExceptionType.NOT_AUTHENTICATED);
+        }
+        return auth;
+    }
+}

--- a/src/main/java/trying/cosmos/global/auth/AuthorityOf.java
+++ b/src/main/java/trying/cosmos/global/auth/AuthorityOf.java
@@ -1,5 +1,7 @@
 package trying.cosmos.global.auth;
 
+import trying.cosmos.global.auth.entity.Authority;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/trying/cosmos/global/auth/entity/AuthKey.java
+++ b/src/main/java/trying/cosmos/global/auth/entity/AuthKey.java
@@ -1,4 +1,4 @@
-package trying.cosmos.global.auth;
+package trying.cosmos.global.auth.entity;
 
 public class AuthKey {
 
@@ -23,7 +23,7 @@ public class AuthKey {
     }
 
     public static boolean needAuthenticate() {
-        return needAuth.get();
+        return needAuth.get() != null && needAuth.get();
     }
 
     public static void setNeed(boolean need) {

--- a/src/main/java/trying/cosmos/global/auth/entity/Authority.java
+++ b/src/main/java/trying/cosmos/global/auth/entity/Authority.java
@@ -1,4 +1,4 @@
-package trying.cosmos.global.auth;
+package trying.cosmos.global.auth.entity;
 
 public enum Authority {
     

--- a/src/main/java/trying/cosmos/global/auth/entity/Session.java
+++ b/src/main/java/trying/cosmos/global/auth/entity/Session.java
@@ -1,0 +1,35 @@
+package trying.cosmos.global.auth.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.entity.UserStatus;
+
+import javax.persistence.Id;
+
+@Getter
+@ToString
+@RedisHash("session")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Session {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private Long userId;
+
+    private Authority authority;
+
+    private UserStatus status;
+
+    public Session(User user) {
+        this.userId = user.getId();
+        this.authority = user.getAuthority();
+        this.status = user.getStatus();
+    }
+}

--- a/src/main/java/trying/cosmos/global/auth/repository/SessionRepository.java
+++ b/src/main/java/trying/cosmos/global/auth/repository/SessionRepository.java
@@ -1,0 +1,10 @@
+package trying.cosmos.global.auth.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import trying.cosmos.global.auth.entity.Session;
+
+import java.util.Optional;
+
+public interface SessionRepository extends CrudRepository<Session, String> {
+    Optional<Session> findByUserId(Long userId);
+}

--- a/src/main/java/trying/cosmos/global/configuration/RedisConfig.java
+++ b/src/main/java/trying/cosmos/global/configuration/RedisConfig.java
@@ -1,0 +1,22 @@
+package trying.cosmos.global.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/trying/cosmos/global/configuration/WebConfig.java
+++ b/src/main/java/trying/cosmos/global/configuration/WebConfig.java
@@ -6,20 +6,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import trying.cosmos.domain.user.repository.UserRepository;
 import trying.cosmos.global.aop.AuthenticationLogInterceptor;
 import trying.cosmos.global.aop.RequestKeyInterceptor;
 import trying.cosmos.global.aop.RequestLogInterceptor;
-import trying.cosmos.global.auth.AnonymousInterceptor;
-import trying.cosmos.global.auth.AuthenticationInterceptor;
-import trying.cosmos.global.auth.TokenProvider;
+import trying.cosmos.global.auth.AuthUtils;
+import trying.cosmos.global.auth.interceptor.AnonymousInterceptor;
+import trying.cosmos.global.auth.interceptor.AuthenticationInterceptor;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final UserRepository userRepository;
-    private final TokenProvider tokenProvider;
+    private final AuthUtils authUtils;
 
     @Value("${cloud.aws.cloudfront.url}")
     private String host;
@@ -28,8 +26,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new RequestKeyInterceptor());
         registry.addInterceptor(new RequestLogInterceptor());
-        registry.addInterceptor(new AuthenticationInterceptor(userRepository, tokenProvider));
-        registry.addInterceptor(new AnonymousInterceptor(userRepository, tokenProvider));
+        registry.addInterceptor(new AuthenticationInterceptor(authUtils));
+        registry.addInterceptor(new AnonymousInterceptor(authUtils));
         registry.addInterceptor(new AuthenticationLogInterceptor());
     }
 

--- a/src/main/java/trying/cosmos/global/dev/DevController.java
+++ b/src/main/java/trying/cosmos/global/dev/DevController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.global.auth.TokenProvider;
+import trying.cosmos.global.auth.entity.Session;
+import trying.cosmos.global.auth.repository.SessionRepository;
 import trying.cosmos.global.dev.response.DevCreateUserResponse;
 import trying.cosmos.global.dev.response.DevPlanetResponse;
 
@@ -18,16 +20,19 @@ public class DevController {
 
     private final DevService devService;
     private final TokenProvider tokenProvider;
+    private final SessionRepository sessionRepository;
 
     @PostMapping("/users")
     public DevCreateUserResponse createUser() {
         User user = devService.createUser();
-        return new DevCreateUserResponse(user, tokenProvider.getAccessToken(user));
+        Session auth = sessionRepository.save(new Session(user));
+        return new DevCreateUserResponse(user, tokenProvider.getAccessToken(auth));
     }
 
     @PostMapping("/planets")
     public DevPlanetResponse createPlanet() {
         User user = devService.createUser();
-        return new DevPlanetResponse(devService.createPlanet(user), tokenProvider.getAccessToken(user));
+        Session auth = sessionRepository.save(new Session(user));
+        return new DevPlanetResponse(devService.createPlanet(user), tokenProvider.getAccessToken(auth));
     }
 }

--- a/src/main/java/trying/cosmos/global/dev/DevService.java
+++ b/src/main/java/trying/cosmos/global/dev/DevService.java
@@ -7,11 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 import trying.cosmos.domain.planet.entity.Planet;
 import trying.cosmos.domain.planet.entity.PlanetImageType;
 import trying.cosmos.domain.planet.repository.PlanetRepository;
-import trying.cosmos.domain.planet.service.PlanetService;
 import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.domain.user.entity.UserStatus;
 import trying.cosmos.domain.user.repository.UserRepository;
-import trying.cosmos.global.auth.Authority;
+import trying.cosmos.global.auth.entity.Authority;
 
 import static org.apache.commons.lang3.RandomStringUtils.random;
 
@@ -23,14 +22,14 @@ public class DevService {
 
     private final UserRepository userRepository;
     private final PlanetRepository planetRepository;
-    private final PlanetService planetService;
 
     private static final String MOCK_DEVICE_TOKEN = "deviceToken";
 
     @Transactional
     public User createUser() {
         String str = randomName();
-        return userRepository.save(new User(str + "@gmail.com", "password", str, UserStatus.LOGIN, Authority.USER));
+        User user = new User(str + "@gmail.com", "password", str, UserStatus.LOGIN, Authority.USER);
+        return userRepository.save(user);
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+  redis:
+    host: localhost
+    port: 6379
 
 logging:
   level:
@@ -39,6 +42,9 @@ spring:
       ddl-auto: create
     properties:
       hibernate:
+  redis:
+    host: localhost
+    port: 6379
 
 logging:
   level:
@@ -54,6 +60,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+  redis:
+    host: localhost
+    port: 6379
 
 logging:
   level:

--- a/src/test/java/trying/cosmos/docs/CertificationDocsTest.java
+++ b/src/test/java/trying/cosmos/docs/CertificationDocsTest.java
@@ -1,6 +1,7 @@
 package trying.cosmos.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import trying.cosmos.domain.certification.dto.request.GenerateCertificationReque
 import trying.cosmos.domain.certification.entity.Certification;
 import trying.cosmos.domain.certification.repository.CertificationRepository;
 import trying.cosmos.domain.certification.service.CertificationService;
+import trying.cosmos.global.auth.repository.SessionRepository;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -55,6 +57,8 @@ public class CertificationDocsTest {
     CertificationService certificationService;
     @Autowired
     CertificationRepository certificationRepository;
+    @Autowired
+    SessionRepository sessionRepository;
 
     @Autowired
     RestDocumentationResultHandler restDocs;
@@ -71,6 +75,11 @@ public class CertificationDocsTest {
                 .alwaysDo(restDocs)
                 .addFilters(new CharacterEncodingFilter("UTF-8",true))
                 .build();
+    }
+
+    @AfterEach
+    void clear() {
+        sessionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/trying/cosmos/docs/CourseDocsTest.java
+++ b/src/test/java/trying/cosmos/docs/CourseDocsTest.java
@@ -1,6 +1,7 @@
 package trying.cosmos.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,8 @@ import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.domain.user.entity.UserStatus;
 import trying.cosmos.domain.user.repository.UserRepository;
 import trying.cosmos.domain.user.service.UserService;
-import trying.cosmos.global.auth.Authority;
+import trying.cosmos.global.auth.entity.Authority;
+import trying.cosmos.global.auth.repository.SessionRepository;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -73,6 +75,8 @@ public class CourseDocsTest {
     @Autowired
     UserRepository userRepository;
     @Autowired
+    SessionRepository sessionRepository;
+    @Autowired
     UserService userService;
     @Autowired
     PlanetService planetService;
@@ -100,6 +104,11 @@ public class CourseDocsTest {
                 .alwaysDo(restDocs)
                 .addFilters(new CharacterEncodingFilter("UTF-8",true))
                 .build();
+    }
+
+    @AfterEach
+    void clear() {
+        sessionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/trying/cosmos/docs/PlanetDocsTest.java
+++ b/src/test/java/trying/cosmos/docs/PlanetDocsTest.java
@@ -1,6 +1,7 @@
 package trying.cosmos.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,8 @@ import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.domain.user.entity.UserStatus;
 import trying.cosmos.domain.user.repository.UserRepository;
 import trying.cosmos.domain.user.service.UserService;
-import trying.cosmos.global.auth.Authority;
+import trying.cosmos.global.auth.entity.Authority;
+import trying.cosmos.global.auth.repository.SessionRepository;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,6 +69,8 @@ public class PlanetDocsTest {
     @Autowired
     UserRepository userRepository;
     @Autowired
+    SessionRepository sessionRepository;
+    @Autowired
     UserService userService;
     @Autowired
     PlanetService planetService;
@@ -93,6 +97,11 @@ public class PlanetDocsTest {
                 .alwaysDo(restDocs)
                 .addFilters(new CharacterEncodingFilter("UTF-8",true))
                 .build();
+    }
+
+    @AfterEach
+    void clear() {
+        sessionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/trying/cosmos/docs/UserDocsTest.java
+++ b/src/test/java/trying/cosmos/docs/UserDocsTest.java
@@ -1,6 +1,7 @@
 package trying.cosmos.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,8 +36,9 @@ import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.domain.user.entity.UserStatus;
 import trying.cosmos.domain.user.repository.UserRepository;
 import trying.cosmos.domain.user.service.UserService;
-import trying.cosmos.global.auth.Authority;
 import trying.cosmos.global.auth.TokenProvider;
+import trying.cosmos.global.auth.entity.Authority;
+import trying.cosmos.global.auth.repository.SessionRepository;
 
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -63,6 +65,8 @@ public class UserDocsTest {
     MockMvc mvc;
     @Autowired
     UserController userController;
+    @Autowired
+    SessionRepository sessionRepository;
     @Autowired
     ObjectMapper objectMapper;
     @Autowired
@@ -100,6 +104,11 @@ public class UserDocsTest {
                 .alwaysDo(restDocs)
                 .addFilters(new CharacterEncodingFilter("UTF-8",true))
                 .build();
+    }
+
+    @AfterEach
+    void clear() {
+        sessionRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/trying/cosmos/test/authentication/AuthenticationTest.java
+++ b/src/test/java/trying/cosmos/test/authentication/AuthenticationTest.java
@@ -16,8 +16,8 @@ import trying.cosmos.domain.user.service.UserService;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static trying.cosmos.global.auth.Authority.ADMIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.ADMIN;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/trying/cosmos/test/authentication/SessionTest.java
+++ b/src/test/java/trying/cosmos/test/authentication/SessionTest.java
@@ -1,0 +1,90 @@
+package trying.cosmos.test.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import trying.cosmos.domain.user.dto.request.UserLoginRequest;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.repository.UserRepository;
+import trying.cosmos.domain.user.service.UserService;
+import trying.cosmos.global.auth.repository.SessionRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static trying.cosmos.test.component.TestVariables.*;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("Session 테스트")
+public class SessionTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    SessionRepository sessionRepository;
+    @Autowired
+    UserService userService;
+    @Autowired
+    MockMvc mvc;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @AfterEach
+    void clear() {
+        sessionRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("로그인시 세션 생성")
+    void login_create() throws Exception {
+        User user = userRepository.save(new User(EMAIL, PASSWORD, USER_NAME));
+        String content = objectMapper.writeValueAsString(new UserLoginRequest(EMAIL, PASSWORD, DEVICE_TOKEN));
+
+        ResultActions actions = mvc.perform(post("/users/login")
+                        .content(content)
+                        .contentType("application/json"));
+
+        actions.andExpect(status().isOk());
+        assertThat(sessionRepository.findByUserId(user.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("로그아웃시 세션 삭제")
+    void logout_delete() throws Exception {
+        User user = userRepository.save(new User(EMAIL, PASSWORD, USER_NAME));
+        String token = userService.login(EMAIL, PASSWORD, DEVICE_TOKEN);
+
+        ResultActions actions = mvc.perform(delete("/users/logout")
+                        .header("accessToken", token)
+                        .contentType("application/json"));
+
+        actions.andExpect(status().isOk());
+        assertThat(sessionRepository.findByUserId(user.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴시 세션 삭제")
+    void withdraw_delete() throws Exception {
+        User user = userRepository.save(new User(EMAIL, PASSWORD, USER_NAME));
+        String token = userService.login(EMAIL, PASSWORD, DEVICE_TOKEN);
+
+        ResultActions actions = mvc.perform(delete("/users")
+                        .header("accessToken", token)
+                        .contentType("application/json"));
+
+        actions.andExpect(status().isOk());
+        assertThat(sessionRepository.findByUserId(user.getId())).isEmpty();
+    }
+}

--- a/src/test/java/trying/cosmos/test/authentication/component/AuthenticationTestController.java
+++ b/src/test/java/trying/cosmos/test/authentication/component/AuthenticationTestController.java
@@ -5,11 +5,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.domain.user.repository.UserRepository;
-import trying.cosmos.global.auth.AuthKey;
 import trying.cosmos.global.auth.AuthorityOf;
+import trying.cosmos.global.auth.entity.AuthKey;
 
-import static trying.cosmos.global.auth.Authority.ADMIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.ADMIN;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 
 @RestController
 public class AuthenticationTestController {

--- a/src/test/java/trying/cosmos/test/course/service/CreateTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/CreateTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.course.entity.Access.PUBLIC;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NO_PERMISSION;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/course/service/DeleteTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/DeleteTest.java
@@ -20,7 +20,7 @@ import trying.cosmos.domain.planet.repository.PlanetRepository;
 import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.domain.user.entity.UserStatus;
 import trying.cosmos.domain.user.repository.UserRepository;
-import trying.cosmos.global.auth.Authority;
+import trying.cosmos.global.auth.entity.Authority;
 import trying.cosmos.global.exception.CustomException;
 
 import java.util.List;

--- a/src/test/java/trying/cosmos/test/course/service/FeedTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/FeedTest.java
@@ -30,7 +30,7 @@ import static trying.cosmos.domain.course.entity.Access.PRIVATE;
 import static trying.cosmos.domain.course.entity.Access.PUBLIC;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/course/service/FindByTitleTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/FindByTitleTest.java
@@ -31,7 +31,7 @@ import static trying.cosmos.domain.course.entity.Access.PRIVATE;
 import static trying.cosmos.domain.course.entity.Access.PUBLIC;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/course/service/FindTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/FindTest.java
@@ -29,7 +29,7 @@ import static trying.cosmos.domain.course.entity.Access.PRIVATE;
 import static trying.cosmos.domain.course.entity.Access.PUBLIC;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NO_DATA;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/course/service/LikeTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/LikeTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.course.entity.Access.PRIVATE;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/course/service/UnlikeTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/UnlikeTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.course.entity.Access.PRIVATE;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/course/service/UpdateTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/UpdateTest.java
@@ -20,7 +20,7 @@ import trying.cosmos.domain.planet.repository.PlanetRepository;
 import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.domain.user.entity.UserStatus;
 import trying.cosmos.domain.user.repository.UserRepository;
-import trying.cosmos.global.auth.Authority;
+import trying.cosmos.global.auth.entity.Authority;
 import trying.cosmos.global.exception.CustomException;
 
 import java.util.List;

--- a/src/test/java/trying/cosmos/test/planet/repository/RemovedTest.java
+++ b/src/test/java/trying/cosmos/test/planet/repository/RemovedTest.java
@@ -19,7 +19,7 @@ import trying.cosmos.domain.user.repository.UserRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/planet/service/CreateTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/CreateTest.java
@@ -17,7 +17,7 @@ import trying.cosmos.domain.user.repository.UserRepository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/planet/service/DeleteTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/DeleteTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NO_PERMISSION;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/planet/service/FindByCodeTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/FindByCodeTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NO_DATA;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/planet/service/FindByNameTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/FindByNameTest.java
@@ -20,7 +20,7 @@ import trying.cosmos.domain.user.repository.UserRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/planet/service/FindCourseTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/FindCourseTest.java
@@ -22,7 +22,7 @@ import trying.cosmos.domain.user.repository.UserRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/planet/service/FollowTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/FollowTest.java
@@ -21,7 +21,7 @@ import trying.cosmos.global.exception.CustomException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.PLANET_FOLLOW_FAILED;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/planet/service/GetFollowPlanetsTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/GetFollowPlanetsTest.java
@@ -20,7 +20,7 @@ import trying.cosmos.domain.user.repository.UserRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/planet/service/GetInviteCodeTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/GetInviteCodeTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NO_DATA;
 import static trying.cosmos.global.exception.ExceptionType.NO_PERMISSION;
 import static trying.cosmos.test.component.TestVariables.*;

--- a/src/test/java/trying/cosmos/test/planet/service/JoinTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/JoinTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.PLANET_JOIN_FAILED;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/planet/service/UnfollowTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/UnfollowTest.java
@@ -21,7 +21,7 @@ import trying.cosmos.global.exception.CustomException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NO_DATA;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/planet/service/UpdateTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/UpdateTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NO_PERMISSION;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/user/service/FindTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/FindTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.planet.entity.PlanetImageType.EARTH;
 import static trying.cosmos.domain.user.entity.UserStatus.*;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NO_DATA;
 import static trying.cosmos.global.exception.ExceptionType.SUSPENDED_USER;
 import static trying.cosmos.test.component.TestVariables.*;

--- a/src/test/java/trying/cosmos/test/user/service/LoginTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/LoginTest.java
@@ -18,7 +18,7 @@ import java.util.NoSuchElementException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.user.entity.UserStatus.*;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.*;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/user/service/LogoutTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/LogoutTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGOUT;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NOT_AUTHENTICATED;
 import static trying.cosmos.test.component.TestVariables.*;
 

--- a/src/test/java/trying/cosmos/test/user/service/ResetPasswordTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/ResetPasswordTest.java
@@ -16,7 +16,7 @@ import trying.cosmos.global.utils.cipher.BCryptUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGOUT;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/user/service/UpdateNameTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/UpdateNameTest.java
@@ -14,7 +14,7 @@ import trying.cosmos.domain.user.service.UserService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/user/service/UpdatePasswordTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/UpdatePasswordTest.java
@@ -15,7 +15,7 @@ import trying.cosmos.global.utils.cipher.BCryptUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static trying.cosmos.domain.user.entity.UserStatus.LOGIN;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.test.component.TestVariables.*;
 
 @SpringBootTest

--- a/src/test/java/trying/cosmos/test/user/service/WithdrawTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/WithdrawTest.java
@@ -16,7 +16,7 @@ import trying.cosmos.global.exception.CustomException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static trying.cosmos.domain.user.entity.UserStatus.*;
-import static trying.cosmos.global.auth.Authority.USER;
+import static trying.cosmos.global.auth.entity.Authority.USER;
 import static trying.cosmos.global.exception.ExceptionType.NOT_AUTHENTICATED;
 import static trying.cosmos.test.component.TestVariables.*;
 


### PR DESCRIPTION
## 🔍 Issue
- Close #48

## 📝 Task
- Redis를 이용하는 방식으로 인증 방식 변경
- 로그인/로그아웃 관리를 위한 세션 추가

## 🐥 Issue
- 한번씩 세션이 생성되지 않거나 삭제되지 않는 문제가 발생한다.(원인 불명)

## 🧐 Reference
- [Spring Boot 에서 Redis 사용하기](https://bcp0109.tistory.com/328)
- [[Redis] Redis 설치 및 간단한 사용 방법 (Mac)](https://wlswoo.tistory.com/44)
- [FindBy in Redis Repository with spring](https://stackoverflow.com/questions/62406125/findby-in-redis-repository-with-spring)
- [redis-cli 명령어 정리](https://freeblogger.tistory.com/10)
- [Spring Data CrudRespository 이용한 CRUD 예제](https://jydlove.tistory.com/69)
