### PR TITLE
[Bug] #67 : 이메일 인증 변경

### DIFF
--- a/src/main/java/trying/cosmos/domain/user/service/UserService.java
+++ b/src/main/java/trying/cosmos/domain/user/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
     private final TokenProvider tokenProvider;
 
     public boolean isExist(String email) {
-        return certificationRepository.existsByEmail(email) || userRepository.existsByEmail(email);
+        return userRepository.existsByEmail(email);
     }
 
     @Transactional

--- a/src/test/java/trying/cosmos/test/certification/service/CreateTest.java
+++ b/src/test/java/trying/cosmos/test/certification/service/CreateTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import trying.cosmos.domain.certification.repository.CertificationRepository;
@@ -16,7 +15,6 @@ import trying.cosmos.global.exception.CustomException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static trying.cosmos.global.exception.ExceptionType.DUPLICATED;
 import static trying.cosmos.global.exception.ExceptionType.EMAIL_DUPLICATED;
 import static trying.cosmos.test.component.TestVariables.*;
 
@@ -50,14 +48,6 @@ public class CreateTest {
     @Nested
     @DisplayName("실패")
     class fail {
-
-        @Test
-        @DisplayName("중복된 이메일의 인증 코드가 존재하는 경우")
-        void duplicate_email_certification() throws Exception {
-            certificationService.createCertificationCode(EMAIL);
-            assertThatThrownBy(() -> certificationService.createCertificationCode(EMAIL))
-                    .isInstanceOf(DataIntegrityViolationException.class);
-        }
 
         @Test
         @DisplayName("중복된 이메일의 사용자가 존재하는 경우")

--- a/src/test/java/trying/cosmos/test/user/service/EmailExistTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/EmailExistTest.java
@@ -35,13 +35,6 @@ public class EmailExistTest {
     class success {
 
         @Test
-        @DisplayName("인증코드로 등록된 이메일이 존재하는 경우 true")
-        void email_in_certification() throws Exception {
-            certificationService.createCertificationCode(EMAIL);
-            assertThat(userService.isExist(EMAIL)).isTrue();
-        }
-
-        @Test
         @DisplayName("같은 이메일의 유저가 존재하는 경우 true")
         void email_in_user() throws Exception {
             userRepository.save(new User(EMAIL, PASSWORD, USER_NAME));

--- a/src/test/java/trying/cosmos/test/user/service/JoinTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/JoinTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import trying.cosmos.domain.certification.entity.Certification;
@@ -20,7 +19,6 @@ import trying.cosmos.global.exception.CustomException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static trying.cosmos.domain.user.entity.UserStatus.LOGOUT;
 import static trying.cosmos.global.exception.ExceptionType.*;
 import static trying.cosmos.test.component.TestVariables.*;
 


### PR DESCRIPTION
## 🔍 Issue
- Close #67

## 📝 Task
- 이메일 인증코드 생성에서 동일한 이메일의 인증코드가 존재하면 기존 인증코드를 삭제하고 재생성
- 인증코드에 포함된 이메일은 이메일 중복체크에서 확인하지 않음

## 🐥 Issue
- 삭제 후 재생성을 했을 때 duplicate 오류 발생
  - hibernate sql 동작 순서때문에 발생한 문제
  - 아래와 같은 순서로 동작
    - Inserts, in the order they were performed
    - Updates
    - Deletion of collection elements
    - Insertion of collection elements
    - Deletes, in the order they were performed
  - 따라서 delete보다 insert가 먼저 실행되기 때문에 오류 발생
  - 이를 해결하기 위해서 delete 후 flush를 하면 된다.

## 🧐 Reference
- [@Transactional에서 JPA로 delete한 뒤 insert가 안될 때, duplicate entry 에러가 날 때 해결하기](https://eocoding.tistory.com/74)
