### PR TITLE
[Feature] #92 : 카카오 로그인 추가

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -45,24 +45,49 @@ include::{snippets}/certification-docs-test/certificate/http-response.adoc[]
 === 1. 애플 회원가입
 
 ==== Request
-include::{snippets}/o-auth-docs-test/join/http-request.adoc[]
-include::{snippets}/o-auth-docs-test/join/request-fields.adoc[]
+include::{snippets}/o-auth-docs-test/join_apple/http-request.adoc[]
+include::{snippets}/o-auth-docs-test/join_apple/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/o-auth-docs-test/join/http-response.adoc[]
-include::{snippets}/o-auth-docs-test/join/response-fields.adoc[]
+include::{snippets}/o-auth-docs-test/join_apple/http-response.adoc[]
+include::{snippets}/o-auth-docs-test/join_apple/response-fields.adoc[]
 
 '''
 
 === 2. 애플 로그인
 
 ==== Request
-include::{snippets}/o-auth-docs-test/login/http-request.adoc[]
-include::{snippets}/o-auth-docs-test/login/request-fields.adoc[]
+include::{snippets}/o-auth-docs-test/login_apple/http-request.adoc[]
+include::{snippets}/o-auth-docs-test/login_apple/request-fields.adoc[]
 
 ==== Response
-include::{snippets}/o-auth-docs-test/login/http-response.adoc[]
-include::{snippets}/o-auth-docs-test/login/response-fields.adoc[]
+include::{snippets}/o-auth-docs-test/login_apple/http-response.adoc[]
+include::{snippets}/o-auth-docs-test/login_apple/response-fields.adoc[]
+
+'''
+
+[[Kakao-Join]]
+=== 3. 카카오 회원가입
+
+==== Request
+include::{snippets}/o-auth-docs-test/join_kakao/http-request.adoc[]
+include::{snippets}/o-auth-docs-test/join_kakao/request-fields.adoc[]
+
+==== Response
+include::{snippets}/o-auth-docs-test/join_kakao/http-response.adoc[]
+include::{snippets}/o-auth-docs-test/join_kakao/response-fields.adoc[]
+
+'''
+
+=== 4. 카카오 로그인
+
+==== Request
+include::{snippets}/o-auth-docs-test/login_kakao/http-request.adoc[]
+include::{snippets}/o-auth-docs-test/login_kakao/request-fields.adoc[]
+
+==== Response
+include::{snippets}/o-auth-docs-test/login_kakao/http-response.adoc[]
+include::{snippets}/o-auth-docs-test/login_kakao/response-fields.adoc[]
 
 '''
 

--- a/src/main/java/trying/cosmos/domain/user/controller/KakaoAuthController.java
+++ b/src/main/java/trying/cosmos/domain/user/controller/KakaoAuthController.java
@@ -12,16 +12,16 @@ import trying.cosmos.domain.user.dto.response.UserLoginResponse;
 import trying.cosmos.domain.user.service.SocialAccountService;
 
 @RestController
-@RequestMapping("/oauth/apple")
+@RequestMapping("/oauth/kakao")
 @RequiredArgsConstructor
-public class AppleAuthController {
+public class KakaoAuthController {
 
     private final SocialAccountService socialAccountService;
 
     @PostMapping
     public UserLoginResponse join(@RequestBody @Validated SocialJoinRequest request) {
         return new UserLoginResponse(socialAccountService.join(
-                "APPLE " + request.getIdentifier(),
+                "KAKAO " + request.getIdentifier(),
                 request.getEmail(),
                 request.getName(),
                 request.getDeviceToken())
@@ -31,7 +31,7 @@ public class AppleAuthController {
     @PostMapping("/login")
     public UserLoginResponse login(@RequestBody @Validated SocialLoginRequest request) {
         return new UserLoginResponse(socialAccountService.login(
-                "APPLE " + request.getIdentifier(),
+                "KAKAO " + request.getIdentifier(),
                 request.getDeviceToken())
         );
     }

--- a/src/main/java/trying/cosmos/domain/user/dto/request/SocialJoinRequest.java
+++ b/src/main/java/trying/cosmos/domain/user/dto/request/SocialJoinRequest.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.Pattern;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class AppleJoinRequest {
+public class SocialJoinRequest {
 
     @NotBlank
     private String identifier;

--- a/src/main/java/trying/cosmos/domain/user/dto/request/SocialLoginRequest.java
+++ b/src/main/java/trying/cosmos/domain/user/dto/request/SocialLoginRequest.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class AppleLoginRequest {
+public class SocialLoginRequest {
 
     private String identifier;
 


### PR DESCRIPTION
## 🔍 Issue
- Close #92

## 📝 Task
- 카카오 로그인 추가

## 🐥 Issue
- 애플 로그인, 카카오 로그인 모두 같은 형식
  - 굳이 나눌 필요가 있을까?
- accessToken에서 Subject id를 "id"로 변경해둔 상태
  - jwt 표준에 맞게 "sub"로 변경
  - 기존 세션들 때문에 보류
- 소셜 로그인에서 로그인과 회원가입을 분리하는 것이 맞는지

## 🧐 Reference
- [시작하기](https://developers.kakao.com/docs/latest/ko/getting-started/sdk-ios)
- [카카오 로그인](https://developers.kakao.com/docs/latest/ko/kakaologin/ios)
