### PR TITLE
[Feature] #95 : 푸시 알림 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ src/main/resources/application-secret.yml
 src/test/java/trying/cosmos/docs/utils/ApiDocumentUtils.java
 src/docs/*
 src/main/resources/static/docs/*
+src/main/resources/firebase
+docker
+sendfile

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,14 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Firebase
+	implementation 'com.google.firebase:firebase-admin:9.1.0'
+	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
+}
+
+tasks.named('jar') {
+	enabled = false
 }
 
 tasks.named('test') {

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -219,6 +219,62 @@ include::{snippets}/user-test/find-activity/request-headers.adoc[]
 include::{snippets}/user-test/find-activity/http-response.adoc[]
 include::{snippets}/user-test/find-activity/response-fields.adoc[]
 
+[[Notification]]
+== 알림
+
+.타겟(TARGET)
+* 알림이 눌렸을 때, 어떤 데이터를 보여주어야 하는지에 대한 정보
+* ex) target: COURSE, targetId: 1 -> 알림을 누르면 id가 1인 코스를 호출(/courses/1)
+* PLANET, COURSE, REVIEW
+* PLANET은 targetId을 반환하지 않음
+
+=== 1. 알림 조회
+.Overview
+* 최근 7일 안에 내가 받을 알림을 최근 순서대로 반환
+
+==== <Request>
+include::{snippets}/notification-test/find/http-request.adoc[]
+include::{snippets}/notification-test/find/request-headers.adoc[]
+
+==== <Response>
+include::{snippets}/notification-test/find/http-response.adoc[]
+include::{snippets}/notification-test/find/response-fields.adoc[]
+
+=== 2. 알림 읽음 표시
+.Overview
+* 아이디에 해당하는 알림을 읽음 표시
+
+==== <Request>
+include::{snippets}/notification-test/mark/http-request.adoc[]
+include::{snippets}/notification-test/mark/request-headers.adoc[]
+include::{snippets}/notification-test/mark/path-parameters.adoc[]
+
+==== <Response>
+include::{snippets}/notification-test/mark/http-response.adoc[]
+
+=== 3. 알림 삭제
+.Overview
+* 아이디에 해당하는 알림을 삭제
+
+==== <Request>
+include::{snippets}/notification-test/remove/http-request.adoc[]
+include::{snippets}/notification-test/remove/request-headers.adoc[]
+include::{snippets}/notification-test/remove/path-parameters.adoc[]
+
+==== <Response>
+include::{snippets}/notification-test/remove/http-response.adoc[]
+
+=== 4. 알림 전체 삭제
+.Overview
+* 사용자의 모든 알림 삭제
+
+==== <Request>
+include::{snippets}/notification-test/remove-all/http-request.adoc[]
+include::{snippets}/notification-test/remove-all/request-headers.adoc[]
+
+==== <Response>
+include::{snippets}/notification-test/remove-all/http-response.adoc[]
+
 [[Planet]]
 == 행성
 

--- a/src/main/java/trying/cosmos/domain/course/dto/response/CourseDateResponse.java
+++ b/src/main/java/trying/cosmos/domain/course/dto/response/CourseDateResponse.java
@@ -17,7 +17,7 @@ public class CourseDateResponse {
 
     public CourseDateResponse(List<LocalDate> dates) {
         this.dates = dates.stream()
-                .map(DateUtils::getFormattedDate)
+                .map(date -> DateUtils.getFormattedDate(date))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/trying/cosmos/domain/course/repository/CourseRepository.java
+++ b/src/main/java/trying/cosmos/domain/course/repository/CourseRepository.java
@@ -59,4 +59,6 @@ public interface CourseRepository extends JpaRepository<Course, Long>, CourseRep
             "and c.isDeleted = false " +
             "order by c.date")
     List<LocalDate> searchCourseDates(Planet planet, LocalDate start, LocalDate end);
+
+    List<Course> findByDate(LocalDate today);
 }

--- a/src/main/java/trying/cosmos/domain/notification/controller/NotificationController.java
+++ b/src/main/java/trying/cosmos/domain/notification/controller/NotificationController.java
@@ -1,0 +1,41 @@
+package trying.cosmos.domain.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import trying.cosmos.domain.notification.dto.NotificationListResponse;
+import trying.cosmos.domain.notification.service.NotificationService;
+import trying.cosmos.global.auth.AuthorityOf;
+import trying.cosmos.global.auth.entity.AuthKey;
+import trying.cosmos.global.auth.entity.Authority;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @AuthorityOf(Authority.USER)
+    @GetMapping
+    public NotificationListResponse getEvents() {
+        return new NotificationListResponse(notificationService.findByUser(AuthKey.getKey()));
+    }
+
+    @AuthorityOf(Authority.USER)
+    @PostMapping("/{notificationId}")
+    public void markAsRead(@PathVariable Long notificationId) {
+        notificationService.markAsRead(AuthKey.getKey(), notificationId);
+    }
+
+    @AuthorityOf(Authority.USER)
+    @DeleteMapping("/{notificationId}")
+    public void delete(@PathVariable Long notificationId) {
+        notificationService.delete(AuthKey.getKey(), notificationId);
+    }
+
+    @AuthorityOf(Authority.USER)
+    @DeleteMapping
+    public void deleteAll() {
+        notificationService.deleteAll(AuthKey.getKey());
+    }
+}

--- a/src/main/java/trying/cosmos/domain/notification/dto/NotificationContent.java
+++ b/src/main/java/trying/cosmos/domain/notification/dto/NotificationContent.java
@@ -1,0 +1,32 @@
+package trying.cosmos.domain.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import trying.cosmos.domain.notification.entity.Notification;
+import trying.cosmos.global.utils.DateUtils;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NotificationContent {
+
+    private Long notificationId;
+    private String title;
+    private String body;
+    private String target;
+    private Long targetId;
+    private String createdDate;
+    private boolean isChecked;
+
+    public NotificationContent(Notification notification) {
+        this.notificationId = notification.getId();
+        this.title = notification.getTitle();
+        this.body = notification.getBody();
+        this.target = notification.getTarget().toString();
+        this.targetId = notification.getTargetId();
+        this.createdDate = DateUtils.getFormattedDate(notification.getCreatedDate(), "yyyy-MM-dd HH:mm:ss");
+        this.isChecked = notification.isChecked();
+    }
+}

--- a/src/main/java/trying/cosmos/domain/notification/dto/NotificationListResponse.java
+++ b/src/main/java/trying/cosmos/domain/notification/dto/NotificationListResponse.java
@@ -1,0 +1,22 @@
+package trying.cosmos.domain.notification.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import trying.cosmos.domain.notification.entity.Notification;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationListResponse {
+
+    private List<NotificationContent> notifications;
+
+    public NotificationListResponse(List<Notification> notifications) {
+        this.notifications = notifications.stream()
+                .map(NotificationContent::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/trying/cosmos/domain/notification/entity/Notification.java
+++ b/src/main/java/trying/cosmos/domain/notification/entity/Notification.java
@@ -1,0 +1,53 @@
+package trying.cosmos.domain.notification.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.global.auditing.DateAuditingEntity;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends DateAuditingEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationTarget target;
+
+    private Long targetId;
+
+    private boolean isChecked;
+
+    private LocalDate expiredDate;
+
+    private static final int LIFETIME = 7;
+
+    public Notification(User user, String title, String body, NotificationTarget target, Long targetId) {
+        this.user = user;
+        this.title = title;
+        this.body = body;
+        this.target = target;
+        this.targetId = targetId;
+        this.isChecked = false;
+        this.expiredDate = LocalDate.now().plusDays(LIFETIME);
+    }
+
+    public void check() {
+        this.isChecked = true;
+    }
+}

--- a/src/main/java/trying/cosmos/domain/notification/entity/NotificationTarget.java
+++ b/src/main/java/trying/cosmos/domain/notification/entity/NotificationTarget.java
@@ -1,0 +1,5 @@
+package trying.cosmos.domain.notification.entity;
+
+public enum NotificationTarget {
+    PLANET, COURSE, REVIEW
+}

--- a/src/main/java/trying/cosmos/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/trying/cosmos/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,22 @@
+package trying.cosmos.domain.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import trying.cosmos.domain.notification.entity.Notification;
+import trying.cosmos.domain.user.entity.User;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+
+    @Query("select n from Notification n where n.user = :user order by n.createdDate desc")
+    List<Notification> findByUser(User user);
+
+    @Modifying
+    @Query("delete from Notification n where n.expiredDate <= :now")
+    void deleteExpired(LocalDate now);
+
+    void deleteByUser(User user);
+}

--- a/src/main/java/trying/cosmos/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/trying/cosmos/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,8 @@
+package trying.cosmos.domain.notification.repository;
+
+import trying.cosmos.domain.user.entity.User;
+
+public interface NotificationRepositoryCustom {
+
+    boolean existsUnreadNotification(User user);
+}

--- a/src/main/java/trying/cosmos/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/trying/cosmos/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,27 @@
+package trying.cosmos.domain.notification.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import trying.cosmos.domain.user.entity.User;
+
+import static trying.cosmos.domain.notification.entity.QNotification.notification;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsUnreadNotification(User user) {
+        Integer fetchOne = queryFactory
+                .selectOne()
+                .from(notification)
+                .where(
+                        notification.user.eq(user),
+                        notification.isChecked.isFalse()
+                )
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+}

--- a/src/main/java/trying/cosmos/domain/notification/service/NotificationService.java
+++ b/src/main/java/trying/cosmos/domain/notification/service/NotificationService.java
@@ -1,0 +1,74 @@
+package trying.cosmos.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import trying.cosmos.domain.notification.entity.Notification;
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.notification.repository.NotificationRepository;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.repository.UserRepository;
+import trying.cosmos.global.exception.CustomException;
+import trying.cosmos.global.exception.ExceptionType;
+import trying.cosmos.global.utils.push.PushUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final PushUtils pushUtils;
+
+    @Transactional
+    public void create(User user, String title, String body, NotificationTarget target, Long targetId) {
+        notificationRepository.save(new Notification(user, title, body, target, targetId));
+        pushUtils.pushTo(user, title, body, target, targetId);
+    }
+
+    public List<Notification> findByUser(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        return notificationRepository.findByUser(user);
+    }
+
+    @Transactional
+    public void markAsRead(Long userId, Long eventId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        Notification notification = notificationRepository.findById(eventId).orElseThrow();
+        if (!notification.getUser().equals(user)) {
+            throw new CustomException(ExceptionType.NO_DATA);
+        }
+
+        notification.check();
+    }
+
+    @Transactional
+    public void delete(Long userId, Long eventId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        Notification notification = notificationRepository.findById(eventId).orElseThrow();
+        if (!notification.getUser().equals(user)) {
+            throw new CustomException(ExceptionType.NO_DATA);
+        }
+
+        notificationRepository.delete(notification);
+    }
+
+    @Transactional
+    public void deleteAll(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        notificationRepository.deleteByUser(user);
+    }
+
+    @Async
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void clear() {
+        notificationRepository.deleteExpired(LocalDate.now());
+    }
+}

--- a/src/main/java/trying/cosmos/domain/planet/service/PlanetService.java
+++ b/src/main/java/trying/cosmos/domain/planet/service/PlanetService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.notification.service.NotificationService;
 import trying.cosmos.domain.planet.entity.Planet;
 import trying.cosmos.domain.planet.repository.PlanetRepository;
 import trying.cosmos.domain.user.entity.User;
@@ -20,6 +22,7 @@ public class PlanetService {
 
     private final UserRepository userRepository;
     private final PlanetRepository planetRepository;
+    private final NotificationService notificationService;
 
     @Transactional
     public Planet create(Long userId, String name, String type) {
@@ -41,7 +44,15 @@ public class PlanetService {
     @Transactional
     public void join(Long userId, String code) {
         Planet planet = planetRepository.searchByInviteCode(code).orElseThrow();
-        planet.join(userRepository.findById(userId).orElseThrow());
+        User user = userRepository.findById(userId).orElseThrow();
+        planet.join(user);
+
+        notificationService.create(
+                user.getMate(),
+                "메이트 행성 도착",
+                "메이트가 행성에 도착했어요",
+                NotificationTarget.PLANET,
+                null);
     }
 
     public Planet find(String inviteCode) {

--- a/src/main/java/trying/cosmos/domain/user/controller/AppleAuthController.java
+++ b/src/main/java/trying/cosmos/domain/user/controller/AppleAuthController.java
@@ -24,8 +24,9 @@ public class AppleAuthController {
                 "APPLE " + request.getIdentifier(),
                 request.getEmail(),
                 request.getName(),
-                request.getDeviceToken())
-        );
+                request.getDeviceToken(),
+                request.isAllowNotification()
+        ));
     }
 
     @PostMapping("/login")

--- a/src/main/java/trying/cosmos/domain/user/controller/KakaoAuthController.java
+++ b/src/main/java/trying/cosmos/domain/user/controller/KakaoAuthController.java
@@ -24,8 +24,9 @@ public class KakaoAuthController {
                 "KAKAO " + request.getIdentifier(),
                 request.getEmail(),
                 request.getName(),
-                request.getDeviceToken())
-        );
+                request.getDeviceToken(),
+                request.isAllowNotification()
+        ));
     }
 
     @PostMapping("/login")

--- a/src/main/java/trying/cosmos/domain/user/controller/UserController.java
+++ b/src/main/java/trying/cosmos/domain/user/controller/UserController.java
@@ -28,18 +28,28 @@ public class UserController {
 
     @PostMapping
     public UserLoginResponse join(@RequestBody @Validated UserJoinRequest request) {
-        return new UserLoginResponse(userService.join(request.getEmail(), request.getPassword(), request.getName(), request.getDeviceToken()));
+        return new UserLoginResponse(userService.join(
+                request.getEmail(),
+                request.getPassword(),
+                request.getName(),
+                request.getDeviceToken(),
+                request.isAllowNotification()
+        ));
     }
 
     @PostMapping("/login")
     public UserLoginResponse login(@RequestBody @Validated UserLoginRequest request) {
-        return new UserLoginResponse(userService.login(request.getEmail(), request.getPassword(), request.getDeviceToken()));
+        return new UserLoginResponse(userService.login(
+                request.getEmail(),
+                request.getPassword(),
+                request.getDeviceToken()
+        ));
     }
 
     @AuthorityOf(USER)
     @GetMapping
     public UserFindResponse findMe() {
-        return new UserFindResponse(userService.find(AuthKey.getKey()));
+        return new UserFindResponse(userService.find(AuthKey.getKey()), userService.hasNotification(AuthKey.getKey()));
     }
 
     @AuthorityOf(USER)

--- a/src/main/java/trying/cosmos/domain/user/dto/request/SocialJoinRequest.java
+++ b/src/main/java/trying/cosmos/domain/user/dto/request/SocialJoinRequest.java
@@ -25,4 +25,6 @@ public class SocialJoinRequest {
 
     @NotBlank
     private String deviceToken;
+
+    private boolean allowNotification;
 }

--- a/src/main/java/trying/cosmos/domain/user/dto/request/UserJoinRequest.java
+++ b/src/main/java/trying/cosmos/domain/user/dto/request/UserJoinRequest.java
@@ -26,4 +26,6 @@ public class UserJoinRequest {
 
     @NotBlank
     private String deviceToken;
+
+    private boolean allowNotification;
 }

--- a/src/main/java/trying/cosmos/domain/user/dto/response/UserFindResponse.java
+++ b/src/main/java/trying/cosmos/domain/user/dto/response/UserFindResponse.java
@@ -14,8 +14,9 @@ public class UserFindResponse {
     private UserFindContent me;
     private UserFindContent mate;
     private UserPlanetResponse planet;
+    private boolean hasNotification;
 
-    public UserFindResponse(User user) {
+    public UserFindResponse(User user, boolean hasNotification) {
         this.me = new UserFindContent(user);
         if (user.getPlanet() != null) {
             this.planet = new UserPlanetResponse(user.getPlanet(), user.getMate() != null);
@@ -23,5 +24,6 @@ public class UserFindResponse {
         if (user.getMate() != null) {
             this.mate = new UserFindContent(user.getMate());
         }
+        this.hasNotification = hasNotification;
     }
 }

--- a/src/main/java/trying/cosmos/domain/user/entity/User.java
+++ b/src/main/java/trying/cosmos/domain/user/entity/User.java
@@ -47,6 +47,8 @@ public class User extends DateAuditingEntity {
 
     private String deviceToken;
 
+    private boolean allowNotification;
+
     @ToString.Exclude
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "planet_id")
@@ -57,28 +59,8 @@ public class User extends DateAuditingEntity {
     @JoinColumn(name = "mate_id")
     private User mate;
 
-    private User(String email, String password, String name) {
-        this.email = email;
-        this.password = BCryptUtils.encrypt(password);
-        this.name = name;
-        this.status = UserStatus.LOGOUT;
-        this.authority = Authority.USER;
-        this.deviceToken = "";
-        this.isSocialAccount = false;
-    }
-
-    private User(String email, String password, String name, UserStatus status, Authority authority) {
-        this.email = email;
-        this.password = BCryptUtils.encrypt(password);
-        this.name = name;
-        this.status = status;
-        this.authority = authority;
-        this.deviceToken = "";
-        this.isSocialAccount = false;
-    }
-
     // Convenient Method
-    public static User createEmailUser(String email, String password, String name, String deviceToken) {
+    public static User createEmailUser(String email, String password, String name, String deviceToken, boolean allowNotification) {
         User user = new User();
         user.email = email;
         user.isSocialAccount = false;
@@ -88,10 +70,11 @@ public class User extends DateAuditingEntity {
         user.status = UserStatus.LOGIN;
         user.authority = Authority.USER;
         user.deviceToken = deviceToken;
+        user.allowNotification = allowNotification;
         return user;
     }
 
-    public static User createSocialUser(String identifier, String email, String name, String deviceToken) {
+    public static User createSocialUser(String identifier, String email, String name, String deviceToken, boolean allowNotification) {
         User user = new User();
         user.email = email;
         user.isSocialAccount = true;
@@ -101,6 +84,7 @@ public class User extends DateAuditingEntity {
         user.status = UserStatus.LOGIN;
         user.authority = Authority.USER;
         user.deviceToken = deviceToken;
+        user.allowNotification = allowNotification;
         return user;
     }
 

--- a/src/main/java/trying/cosmos/domain/user/repository/UserRepository.java
+++ b/src/main/java/trying/cosmos/domain/user/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package trying.cosmos.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import trying.cosmos.domain.user.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -16,4 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByIdentifier(String identifier);
 
     boolean existsByIdentifier(String identifier);
+
+    @Query("select u from User u where u.status = trying.cosmos.domain.user.entity.UserStatus.LOGIN")
+    List<User> findLoginUsers();
 }

--- a/src/main/java/trying/cosmos/domain/user/service/SocialAccountService.java
+++ b/src/main/java/trying/cosmos/domain/user/service/SocialAccountService.java
@@ -21,7 +21,7 @@ public class SocialAccountService {
     private final TokenProvider tokenProvider;
 
     @Transactional
-    public String join(String identifier, String email, String name, String deviceToken) {
+    public String join(String identifier, String email, String name, String deviceToken, boolean allowNotification) {
         if (userRepository.existsByIdentifier(identifier)) {
             throw new CustomException(ExceptionType.IDENTIFIER_DUPLICATED);
         }
@@ -32,7 +32,7 @@ public class SocialAccountService {
             throw new CustomException(ExceptionType.NAME_DUPLICATED);
         }
 
-        User user = userRepository.save(User.createSocialUser(identifier, email, name, deviceToken));
+        User user = userRepository.save(User.createSocialUser(identifier, email, name, deviceToken, allowNotification));
         Session auth = sessionService.create(user);
         return tokenProvider.getAccessToken(auth);
     }

--- a/src/main/java/trying/cosmos/global/dev/DevController.java
+++ b/src/main/java/trying/cosmos/global/dev/DevController.java
@@ -5,12 +5,13 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import trying.cosmos.domain.course.service.CourseService;
 import trying.cosmos.domain.user.entity.User;
 import trying.cosmos.global.auth.SessionService;
 import trying.cosmos.global.auth.TokenProvider;
 import trying.cosmos.global.auth.entity.Session;
-import trying.cosmos.global.dev.response.DevCreateUserResponse;
 import trying.cosmos.global.dev.response.DevPlanetResponse;
+import trying.cosmos.global.dev.response.DevUserResponse;
 
 @RestController
 @RequestMapping("/dev")
@@ -21,19 +22,32 @@ public class DevController {
     private final DevService devService;
     private final TokenProvider tokenProvider;
     private final SessionService sessionService;
+    private final CourseService courseService;
 
-    @PostMapping("/users")
-    public DevCreateUserResponse createUser() {
+    @PostMapping("/user")
+    public DevUserResponse createUser() {
         User user = devService.createUser();
         Session auth = sessionService.create(user);
-        return new DevCreateUserResponse(user, tokenProvider.getAccessToken(auth));
+        return new DevUserResponse(user, tokenProvider.getAccessToken(auth));
     }
 
-    @PostMapping("/planets")
+    @PostMapping("/planet")
     public DevPlanetResponse createPlanet() {
+        User user = devService.createUser();
+        Session auth = sessionService.create(user);
+        return new DevPlanetResponse(devService.createPlanet(user), tokenProvider.getAccessToken(auth));
+    }
+
+    @PostMapping("/mate")
+    public DevPlanetResponse createMate() {
         User user = devService.createUser();
         User mate = devService.createUser();
         Session auth = sessionService.create(user);
-        return new DevPlanetResponse(devService.createPlanet(user, mate), tokenProvider.getAccessToken(auth));
+        return new DevPlanetResponse(devService.createMate(user, mate), tokenProvider.getAccessToken(auth));
+    }
+
+    @PostMapping("/push")
+    public void pushTodayDate() {
+        courseService.pushTodayCourse();
     }
 }

--- a/src/main/java/trying/cosmos/global/dev/DevService.java
+++ b/src/main/java/trying/cosmos/global/dev/DevService.java
@@ -37,12 +37,17 @@ public class DevService {
     @Transactional
     public User createUser() {
         String str = randomName();
-        User user = User.createEmailUser(str + "@gmail.com", "password", str, "device_token");
+        User user = User.createEmailUser(str + "@gmail.com", "password", str, "device_token", true);
         return userRepository.save(user);
     }
 
     @Transactional
-    public Planet createPlanet(User user, User mate) {
+    public Planet createPlanet(User user) {
+        return planetService.create(user.getId(), randomName(), "EARTH");
+    }
+
+    @Transactional
+    public Planet createMate(User user, User mate) {
         Planet planet = planetService.create(user.getId(), randomName(), "EARTH");
         planetService.join(mate.getId(), planet.getInviteCode());
         return planet;

--- a/src/main/java/trying/cosmos/global/dev/response/DevPlanetResponse.java
+++ b/src/main/java/trying/cosmos/global/dev/response/DevPlanetResponse.java
@@ -11,11 +11,11 @@ import trying.cosmos.domain.planet.entity.Planet;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DevPlanetResponse {
 
-    private DevCreateUserResponse owner;
+    private DevUserResponse owner;
     private DevPlanetContent planet;
 
     public DevPlanetResponse(Planet planet, String accessToken) {
-        this.owner = new DevCreateUserResponse(planet.getOwners().get(0), accessToken);
+        this.owner = new DevUserResponse(planet.getOwners().get(0), accessToken);
         this.planet = new DevPlanetContent(planet);
     }
 }

--- a/src/main/java/trying/cosmos/global/dev/response/DevUserResponse.java
+++ b/src/main/java/trying/cosmos/global/dev/response/DevUserResponse.java
@@ -9,14 +9,14 @@ import trying.cosmos.domain.user.entity.User;
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DevCreateUserResponse {
+public class DevUserResponse {
 
     private String email;
     private String password;
     private String name;
     private String accessToken;
 
-    public DevCreateUserResponse(User user, String accessToken) {
+    public DevUserResponse(User user, String accessToken) {
         this.email = user.getEmail();
         this.password = "password";
         this.name = user.getName();

--- a/src/main/java/trying/cosmos/global/utils/DateUtils.java
+++ b/src/main/java/trying/cosmos/global/utils/DateUtils.java
@@ -4,12 +4,25 @@ import trying.cosmos.global.exception.CustomException;
 import trying.cosmos.global.exception.ExceptionType;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public interface DateUtils {
 
     static String getFormattedDate(LocalDate date) {
         return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+    static String getFormattedDate(LocalDateTime date) {
+        return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    static String getFormattedDate(LocalDate date, String pattern) {
+        return date.format(DateTimeFormatter.ofPattern(pattern));
+    }
+
+    static String getFormattedDate(LocalDateTime date, String pattern) {
+        return date.format(DateTimeFormatter.ofPattern(pattern));
     }
 
     static LocalDate stringToDate(String dateString) {

--- a/src/main/java/trying/cosmos/global/utils/push/PushUtils.java
+++ b/src/main/java/trying/cosmos/global/utils/push/PushUtils.java
@@ -1,0 +1,10 @@
+package trying.cosmos.global.utils.push;
+
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.user.entity.User;
+
+public interface PushUtils {
+
+    void pushAll(String title, String body);
+    void pushTo(User user, String title, String body, NotificationTarget type, Long targetId);
+}

--- a/src/main/java/trying/cosmos/global/utils/push/dto/PushRequest.java
+++ b/src/main/java/trying/cosmos/global/utils/push/dto/PushRequest.java
@@ -1,0 +1,35 @@
+package trying.cosmos.global.utils.push.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PushRequest {
+
+    private boolean validate_only;
+    private Message message;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Message {
+        private String token;
+        private Notification notification;
+        private Data data;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Notification {
+        private String title;
+        private String body;
+        private String image;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Data {
+        private String target;
+        private String targetId;
+    }
+}

--- a/src/main/java/trying/cosmos/global/utils/push/fcm/FcmUtils.java
+++ b/src/main/java/trying/cosmos/global/utils/push/fcm/FcmUtils.java
@@ -1,0 +1,106 @@
+package trying.cosmos.global.utils.push.fcm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.entity.UserStatus;
+import trying.cosmos.domain.user.service.UserService;
+import trying.cosmos.global.aop.LogSpace;
+import trying.cosmos.global.utils.push.PushUtils;
+import trying.cosmos.global.utils.push.dto.PushRequest;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FcmUtils implements PushUtils {
+
+    private static final String FIREBASE_CONFIG_PATH = "firebase/firebase_service_key.json";
+    private static final String GOOGLE_API_URL = "https://www.googleapis.com/auth/cloud-platform";
+
+    @Value("${firebase.appid}")
+    private String clientAppId;
+    private String clientPushAPI;
+
+    @PostConstruct
+    public void init() {
+        this.clientPushAPI = "https://fcm.googleapis.com/v1/projects/" + clientAppId + "/messages:send";
+    }
+
+    private final ObjectMapper objectMapper;
+    private final UserService userService;
+
+    @Async
+    public void pushAll(String title, String body) {
+        for (User user : userService.findLoginUsers()) {
+            sendMessageTo(user, title, body, null, null);
+        }
+    }
+
+    @Async
+    public void pushTo(User member, String title, String body, NotificationTarget type, Long targetId) {
+        sendMessageTo(member, title, body, type, targetId);
+    }
+
+    private boolean sendMessageTo(User user, String title, String body, NotificationTarget type, Long targetId) {
+        if (!user.getStatus().equals(UserStatus.LOGIN)) {
+            return false;
+        }
+        if (!user.isAllowNotification()) {
+            return false;
+        }
+
+        try {
+            String message = makeMessage(user.getDeviceToken(), title, body, type, targetId);
+            log.info("{}[FCM] Send message to {}", LogSpace.getSpace(), user.getId());
+
+            OkHttpClient client = new OkHttpClient();
+            RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+            Request request = new Request.Builder()
+                    .url(clientPushAPI)
+                    .post(requestBody)
+                    .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+                    .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
+                    .build();
+
+            Response response = client.newCall(request).execute();
+            response.close();
+            return response.code() == 200;
+        } catch (IOException e) {
+            throw new RuntimeException("Push Message 전송 오류");
+        }
+    }
+
+    private String makeMessage(String targetToken, String title, String body, NotificationTarget type, Long targetId) throws JsonProcessingException {
+        PushRequest.Notification notification = new PushRequest.Notification(title, body, null);
+        PushRequest.Data data = new PushRequest.Data(type.toString(), String.valueOf(targetId));
+        PushRequest.Message message = new PushRequest.Message(targetToken, notification, data);
+        PushRequest pushRequest = new PushRequest(false, message);
+
+        return objectMapper.writeValueAsString(pushRequest);
+    }
+
+    private String getAccessToken() {
+        try {
+            GoogleCredentials googleCredentials = GoogleCredentials.fromStream(
+                    new ClassPathResource(FIREBASE_CONFIG_PATH).getInputStream()).createScoped(List.of(GOOGLE_API_URL));
+            googleCredentials.refreshIfExpired();
+            return googleCredentials.getAccessToken().getTokenValue();
+        } catch (IOException e) {
+            throw new RuntimeException("Google 인증 오류");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,21 @@ spring:
 spring:
   config:
     activate:
+      on-profile: prod
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+logging:
+  level:
+    trying.cosmos: debug
+
+
+---
+
+spring:
+  config:
+    activate:
       on-profile: dev
   jpa:
     hibernate:

--- a/src/test/java/trying/cosmos/CosmosApplicationTests.java
+++ b/src/test/java/trying/cosmos/CosmosApplicationTests.java
@@ -2,7 +2,9 @@ package trying.cosmos;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class CosmosApplicationTests {
 

--- a/src/test/java/trying/cosmos/docs/CourseReviewTest.java
+++ b/src/test/java/trying/cosmos/docs/CourseReviewTest.java
@@ -117,8 +117,8 @@ public class CourseReviewTest {
     @DisplayName("코스 리뷰 생성")
     void create() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -163,8 +163,8 @@ public class CourseReviewTest {
     @DisplayName("코스 리뷰 수정")
     void update() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -217,8 +217,8 @@ public class CourseReviewTest {
     @DisplayName("코스 리뷰 삭제")
     void remove() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -254,8 +254,8 @@ public class CourseReviewTest {
     @DisplayName("코스 리뷰 조회")
     void findReview() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);

--- a/src/test/java/trying/cosmos/docs/CourseTest.java
+++ b/src/test/java/trying/cosmos/docs/CourseTest.java
@@ -116,8 +116,8 @@ public class CourseTest {
     @DisplayName("코스 생성")
     void create() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -167,8 +167,8 @@ public class CourseTest {
     @DisplayName("코스 수정")
     void update() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -227,8 +227,8 @@ public class CourseTest {
     @DisplayName("코스 삭제")
     void remove() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -263,8 +263,8 @@ public class CourseTest {
     @DisplayName("아이디로 코스 조회")
     void findById() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -338,8 +338,8 @@ public class CourseTest {
     @DisplayName("날짜로 코스 조회")
     void findByDate() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -413,8 +413,8 @@ public class CourseTest {
     @DisplayName("코스 목록 조회")
     void findList() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -511,8 +511,8 @@ public class CourseTest {
     @DisplayName("로그 조회")
     void log() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -600,8 +600,8 @@ public class CourseTest {
     @DisplayName("코스가 존재하는 날짜 조회")
     void courseExistDate() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -647,8 +647,8 @@ public class CourseTest {
     @DisplayName("코스 좋아요")
     void like() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -683,8 +683,8 @@ public class CourseTest {
     @DisplayName("코스 좋아요 취소")
     void unlike() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);

--- a/src/test/java/trying/cosmos/docs/EmailUserTest.java
+++ b/src/test/java/trying/cosmos/docs/EmailUserTest.java
@@ -36,6 +36,7 @@ import trying.cosmos.global.auth.SessionService;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -146,7 +147,7 @@ public class EmailUserTest {
         // GIVEN
         Certification certification = certificationRepository.save(new Certification(MY_EMAIL));
         certification.certificate(certification.getCode());
-        String content = objectMapper.writeValueAsString(new UserJoinRequest(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        String content = objectMapper.writeValueAsString(new UserJoinRequest(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
 
         // WHEN
         ResultActions actions = mvc.perform(post("/users")
@@ -173,7 +174,10 @@ public class EmailUserTest {
                                 .attributes(constraints("2~8자리 한글/영어/숫자")),
                         fieldWithPath("deviceToken")
                                 .type(STRING)
-                                .description("디바이스 토큰")
+                                .description("디바이스 토큰"),
+                        fieldWithPath("allowNotification")
+                                .type(BOOLEAN)
+                                .description("알림 허용 여부")
                 ),
                 responseFields(
                         fieldWithPath("accessToken")
@@ -187,7 +191,7 @@ public class EmailUserTest {
     @DisplayName("이메일로 로그인")
     void login() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         String content = objectMapper.writeValueAsString(new UserLoginRequest(MY_EMAIL, PASSWORD, DEVICE_TOKEN));
 
         // WHEN

--- a/src/test/java/trying/cosmos/docs/NotificationTest.java
+++ b/src/test/java/trying/cosmos/docs/NotificationTest.java
@@ -1,0 +1,236 @@
+package trying.cosmos.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import trying.cosmos.docs.utils.RestDocsConfiguration;
+import trying.cosmos.domain.notification.entity.Notification;
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.notification.repository.NotificationRepository;
+import trying.cosmos.domain.planet.entity.Planet;
+import trying.cosmos.domain.planet.repository.PlanetRepository;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.repository.UserRepository;
+import trying.cosmos.domain.user.service.UserService;
+import trying.cosmos.global.auth.SessionService;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static trying.cosmos.docs.utils.DocsVariable.*;
+import static trying.cosmos.docs.utils.RestDocsConfiguration.constraints;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("[DOCS] 알림")
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@Import(RestDocsConfiguration.class)
+@ExtendWith({RestDocumentationExtension.class})
+public class NotificationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    PlanetRepository planetRepository;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    // Docs
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    RestDocumentationResultHandler restDocs;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    SessionService sessionService;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider, WebApplicationContext context){
+        this.mvc= MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .alwaysDo(restDocs)
+                .addFilters(new CharacterEncodingFilter("UTF-8",true))
+                .build();
+    }
+
+    @AfterEach
+    void clearSession() {
+        sessionService.clear();
+    }
+    
+    @Test
+    @DisplayName("알림 조회")
+    void find() throws Exception {
+        // GIVEN
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
+        Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
+        planet.join(mate);
+        Notification notification = notificationRepository.save(new Notification(user, NOTIFICATION__TITLE, NOTIFICATION__BODY, NotificationTarget.COURSE, 1L));
+
+        // WHEN
+        ResultActions actions = mvc.perform(get("/notifications")
+                .header(ACCESS_TOKEN, accessToken));
+
+        actions.andExpect(status().isOk());
+
+        // THEN
+        actions.andDo(restDocs.document(
+                requestHeaders(
+                        headerWithName(ACCESS_TOKEN)
+                                .description("인증 토큰")
+                ),
+                responseFields(
+                        fieldWithPath("notifications[].notificationId")
+                                .type(NUMBER)
+                                .description("알림 id"),
+                        fieldWithPath("notifications[].title")
+                                .type(STRING)
+                                .description("알림 제목"),
+                        fieldWithPath("notifications[].body")
+                                .type(STRING)
+                                .description("알림 본문"),
+                        fieldWithPath("notifications[].target")
+                                .type(STRING)
+                                .description("알림을 눌렀을 때 연결시켜야 할 데이터 타입")
+                                .attributes(constraints("PLANET, COURSE, REVIEW 중 하나")),
+                        fieldWithPath("notifications[].targetId")
+                                .type(NUMBER)
+                                .description("알림을 눌렀을 때 연결시켜야 할 데이터 타입"),
+                        fieldWithPath("notifications[].createdDate")
+                                .type(STRING)
+                                .description("알림 생성일"),
+                        fieldWithPath("notifications[].checked")
+                                .type(BOOLEAN)
+                                .description("알림 확인 여부")
+
+                )
+        ));
+    }
+
+    @Test
+    @DisplayName("알림 읽음 표시")
+    void mark() throws Exception {
+        // GIVEN
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
+        Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
+        planet.join(mate);
+        Notification notification = notificationRepository.save(new Notification(user, NOTIFICATION__TITLE, NOTIFICATION__BODY, NotificationTarget.COURSE, 1L));
+
+        // WHEN
+        ResultActions actions = mvc.perform(post("/notifications/{notificationId}", notification.getId())
+                .header(ACCESS_TOKEN, accessToken));
+
+        actions.andExpect(status().isOk());
+
+        // THEN
+        actions.andDo(restDocs.document(
+                requestHeaders(
+                        headerWithName(ACCESS_TOKEN)
+                                .description("인증 토큰")
+                ),
+                pathParameters(
+                        parameterWithName("notificationId")
+                                .description("알림 id")
+                                .attributes(key("type").value("Number"))
+                )
+        ));
+    }
+
+    @Test
+    @DisplayName("알림 삭제")
+    void remove() throws Exception {
+        // GIVEN
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
+        Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
+        planet.join(mate);
+        Notification notification = notificationRepository.save(new Notification(user, NOTIFICATION__TITLE, NOTIFICATION__BODY, NotificationTarget.COURSE, 1L));
+
+        // WHEN
+        ResultActions actions = mvc.perform(delete("/notifications/{notificationId}", notification.getId())
+                .header(ACCESS_TOKEN, accessToken));
+
+        // THEN
+        actions.andDo(restDocs.document(
+                requestHeaders(
+                        headerWithName(ACCESS_TOKEN)
+                                .description("인증 토큰")
+                ),
+                pathParameters(
+                        parameterWithName("notificationId")
+                                .description("알림 id")
+                                .attributes(key("type").value("Number"))
+                )
+        ));
+    }
+
+    @Test
+    @DisplayName("알림 전체 삭제")
+    void removeAll() throws Exception {
+        // GIVEN
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
+        Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
+        planet.join(mate);
+        Notification notification = notificationRepository.save(new Notification(user, NOTIFICATION__TITLE, NOTIFICATION__BODY, NotificationTarget.COURSE, 1L));
+
+        // WHEN
+        ResultActions actions = mvc.perform(delete("/notifications")
+                .header(ACCESS_TOKEN, accessToken));
+
+        // THEN
+        actions.andDo(restDocs.document(
+                requestHeaders(
+                        headerWithName(ACCESS_TOKEN)
+                                .description("인증 토큰")
+                )
+        ));
+    }
+}

--- a/src/test/java/trying/cosmos/docs/PlaceTest.java
+++ b/src/test/java/trying/cosmos/docs/PlaceTest.java
@@ -107,8 +107,8 @@ public class PlaceTest {
     @DisplayName("아이디로 장소 조회")
     void findById() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -159,8 +159,8 @@ public class PlaceTest {
     @DisplayName("이름으로 장소 조회")
     void findByName() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -233,8 +233,8 @@ public class PlaceTest {
     @DisplayName("위치로 장소 조회")
     void findByLocation() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);

--- a/src/test/java/trying/cosmos/docs/PlanetTest.java
+++ b/src/test/java/trying/cosmos/docs/PlanetTest.java
@@ -101,7 +101,7 @@ public class PlanetTest {
     @DisplayName("행성 생성")
     void create() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
 
         String content = objectMapper.writeValueAsString(new PlanetCreateRequest(PLANET_NAME, IMAGE_NAME));
@@ -142,7 +142,7 @@ public class PlanetTest {
     @DisplayName("행성 조회")
     void find() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
 
@@ -181,8 +181,8 @@ public class PlanetTest {
     @DisplayName("행성 참가")
     void join() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(mate, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
 
@@ -215,8 +215,8 @@ public class PlanetTest {
     @DisplayName("행성 수정")
     void update() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -268,8 +268,8 @@ public class PlanetTest {
     @DisplayName("행성 나가기")
     void leave() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);

--- a/src/test/java/trying/cosmos/docs/SocialUserTest.java
+++ b/src/test/java/trying/cosmos/docs/SocialUserTest.java
@@ -31,6 +31,7 @@ import trying.cosmos.domain.user.repository.UserRepository;
 import trying.cosmos.global.auth.SessionService;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -82,7 +83,7 @@ public class SocialUserTest {
     @DisplayName("애플 계정으로 회원가입")
     void joinWithApple() throws Exception {
         // GIVEN
-        String content = objectMapper.writeValueAsString(new SocialJoinRequest(IDENTIFIER, MY_EMAIL, MY_NAME, DEVICE_TOKEN));
+        String content = objectMapper.writeValueAsString(new SocialJoinRequest(IDENTIFIER, MY_EMAIL, MY_NAME, DEVICE_TOKEN, true));
 
         // WHEN
         ResultActions actions = mvc.perform(post("/oauth/apple")
@@ -109,7 +110,10 @@ public class SocialUserTest {
                                 .attributes(constraints("2~8자리 한글/영어/숫자")),
                         fieldWithPath("deviceToken")
                                 .type(STRING)
-                                .description("디바이스 토큰")
+                                .description("디바이스 토큰"),
+                        fieldWithPath("allowNotification")
+                                .type(BOOLEAN)
+                                .description("알림 허용 여부")
                 ),
                 responseFields(
                         fieldWithPath("accessToken")
@@ -123,7 +127,7 @@ public class SocialUserTest {
     @DisplayName("애플 계정으로 로그인")
     void loginWithApple() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createSocialUser("APPLE " + IDENTIFIER, MY_EMAIL, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createSocialUser("APPLE " + IDENTIFIER, MY_EMAIL, MY_NAME, DEVICE_TOKEN, true));
         String content = objectMapper.writeValueAsString(new SocialLoginRequest(IDENTIFIER, DEVICE_TOKEN));
 
         // WHEN
@@ -156,7 +160,7 @@ public class SocialUserTest {
     @DisplayName("카카오 계정으로 회원가입")
     void joinWithKakao() throws Exception {
         // GIVEN
-        String content = objectMapper.writeValueAsString(new SocialJoinRequest(IDENTIFIER, MY_EMAIL, MY_NAME, DEVICE_TOKEN));
+        String content = objectMapper.writeValueAsString(new SocialJoinRequest(IDENTIFIER, MY_EMAIL, MY_NAME, DEVICE_TOKEN, true));
 
         // WHEN
         ResultActions actions = mvc.perform(post("/oauth/kakao")
@@ -183,7 +187,10 @@ public class SocialUserTest {
                                 .attributes(constraints("2~8자리 한글/영어/숫자")),
                         fieldWithPath("deviceToken")
                                 .type(STRING)
-                                .description("디바이스 토큰")
+                                .description("디바이스 토큰"),
+                        fieldWithPath("allowNotification")
+                                .type(BOOLEAN)
+                                .description("알림 허용 여부")
                 ),
                 responseFields(
                         fieldWithPath("accessToken")
@@ -197,7 +204,7 @@ public class SocialUserTest {
     @DisplayName("카카오 계정으로 로그인")
     void loginWithKakao() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createSocialUser("KAKAO " + IDENTIFIER, MY_EMAIL, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createSocialUser("KAKAO " + IDENTIFIER, MY_EMAIL, MY_NAME, DEVICE_TOKEN, true));
         String content = objectMapper.writeValueAsString(new SocialLoginRequest(IDENTIFIER, DEVICE_TOKEN));
 
         // WHEN

--- a/src/test/java/trying/cosmos/docs/UserTest.java
+++ b/src/test/java/trying/cosmos/docs/UserTest.java
@@ -37,8 +37,7 @@ import trying.cosmos.global.auth.SessionService;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static trying.cosmos.docs.utils.DocsVariable.*;
@@ -95,7 +94,7 @@ public class UserTest {
     @DisplayName("로그아웃")
     void logout() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
 
         // WHEN
@@ -119,7 +118,7 @@ public class UserTest {
     @DisplayName("회원탈퇴")
     void withdraw() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
 
         // WHEN
@@ -143,7 +142,7 @@ public class UserTest {
     @DisplayName("닉네임 수정")
     void updateName() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
         String content = objectMapper.writeValueAsString(new UserUpdateNameRequest("UPDATED"));
 
@@ -175,7 +174,7 @@ public class UserTest {
     @DisplayName("비밀번호 수정")
     void updatePassword() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
         String content = objectMapper.writeValueAsString(new UserUpdatePasswordRequest("!Updated1234"));
 
@@ -207,7 +206,7 @@ public class UserTest {
     @DisplayName("비밀번호 초기화")
     void resetPassword() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         String content = objectMapper.writeValueAsString(new UserResetPasswordRequest(MY_EMAIL));
 
         // WHEN
@@ -233,7 +232,7 @@ public class UserTest {
     @DisplayName("내 정보 조회(행성, 메이트 없음)")
     void findMe() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
 
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
 
@@ -254,7 +253,10 @@ public class UserTest {
                 responseFields(
                         fieldWithPath("me.name")
                                 .type(STRING)
-                                .description("사용자 닉네임")
+                                .description("사용자 닉네임"),
+                        fieldWithPath("hasNotification")
+                                .type(BOOLEAN)
+                                .description("읽지 않은 알림이 있는지 여부")
                 )
         ));
     }
@@ -263,7 +265,7 @@ public class UserTest {
     @DisplayName("내 정보 조회(메이트 없음)")
     void findMePlanet() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
 
         String accessToken = userService.login(MY_EMAIL, PASSWORD, DEVICE_TOKEN);
@@ -298,7 +300,10 @@ public class UserTest {
                                 .description("행성 이미지 타입"),
                         fieldWithPath("planet.code")
                                 .type(STRING)
-                                .description("행성 초대 코드")
+                                .description("행성 초대 코드"),
+                        fieldWithPath("hasNotification")
+                                .type(BOOLEAN)
+                                .description("읽지 않은 알림이 있는지 여부")
                 )
         ));
     }
@@ -307,8 +312,8 @@ public class UserTest {
     @DisplayName("내 정보 조회(메이트 존재)")
     void findMeMate() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
 
@@ -344,7 +349,10 @@ public class UserTest {
                                 .attributes(constraints("양수(오늘 이전 날짜 불가)")),
                         fieldWithPath("planet.image")
                                 .type(STRING)
-                                .description("행성 이미지 타입")
+                                .description("행성 이미지 타입"),
+                        fieldWithPath("hasNotification")
+                                .type(BOOLEAN)
+                                .description("읽지 않은 알림이 있는지 여부")
                 )
         ));
     }
@@ -353,8 +361,8 @@ public class UserTest {
     @DisplayName("내 활동 조회")
     void findActivity() throws Exception {
         // GIVEN
-        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN));
-        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN));
+        User user = userRepository.save(User.createEmailUser(MY_EMAIL, PASSWORD, MY_NAME, DEVICE_TOKEN, true));
+        User mate = userRepository.save(User.createEmailUser(MATE_EMAIL, PASSWORD, MATE_NAME, DEVICE_TOKEN, true));
         Planet planet = planetRepository.save(new Planet(user, PLANET_NAME, IMAGE_NAME, INVITE_CODE));
         planet.join(mate);
 

--- a/src/test/java/trying/cosmos/docs/utils/DocsVariable.java
+++ b/src/test/java/trying/cosmos/docs/utils/DocsVariable.java
@@ -26,4 +26,8 @@ public abstract class DocsVariable {
     public static final String CONTENT = "CONTENT";
     public static final Place PLACE1 = new Place(1L, "Place1", "CODE", "ADDRESS", "ADDRESS", 0.0, 0.0);
     public static final Place PLACE2 = new Place(2L, "Place2", "CODE", "ADDRESS", "ADDRESS", 0.1, 0.2);
+
+    public static final String NOTIFICATION__TITLE = "title";
+    public static final String NOTIFICATION__BODY = "body";
+    public static final Long NOTIFICATION_TARGET_ID = 1L;
 }

--- a/src/test/java/trying/cosmos/test/certification/service/GenerateCertificationTest.java
+++ b/src/test/java/trying/cosmos/test/certification/service/GenerateCertificationTest.java
@@ -42,7 +42,7 @@ public class GenerateCertificationTest {
         @DisplayName("사용자가 존재한다면 EMAIL_DUPLICATED 오류를 발생시킨다.")
         void email_duplicate() throws Exception {
             // GIVEN
-            userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> certificationService.generate(EMAIL1))

--- a/src/test/java/trying/cosmos/test/course/service/CreateTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/CreateTest.java
@@ -57,37 +57,37 @@ public class CreateTest {
     class fail {
 
         @Test
-        @DisplayName("행성이 존재하지 않으면 PLANET_CREATE_FAILED 오류를 발생시킨다.")
+        @DisplayName("행성이 존재하지 않으면 NO_PLANET 오류를 발생시킨다.")
         void no_planet() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> courseService.create(user.getId(), TITLE, LocalDate.now(), course_place_request1))
                     .isInstanceOf(CustomException.class)
-                    .hasMessage(ExceptionType.PLANET_CREATE_FAILED.getMessage());
+                    .hasMessage(ExceptionType.NO_PLANET.getMessage());
         }
 
-        @Test
-        @DisplayName("메이트가 존재하지 않으면 PLANET_CREATE_FAILED 오류를 발생시킨다.")
-        void no_mate() throws Exception {
-            // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
-
-            // WHEN THEN
-            assertThatThrownBy(() -> courseService.create(user.getId(), TITLE, LocalDate.now(), course_place_request1))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ExceptionType.PLANET_CREATE_FAILED.getMessage());
-        }
+//        @Test
+//        @DisplayName("메이트가 존재하지 않으면 PLANET_CREATE_FAILED 오류를 발생시킨다.")
+//        void no_mate() throws Exception {
+//            // GIVEN
+//            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+//            Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
+//
+//            // WHEN THEN
+//            assertThatThrownBy(() -> courseService.create(user.getId(), TITLE, LocalDate.now(), course_place_request1))
+//                    .isInstanceOf(CustomException.class)
+//                    .hasMessage(ExceptionType.PLANET_CREATE_FAILED.getMessage());
+//        }
 
         @Test
         @DisplayName("해당 날짜에 코스가 존재한다면 DUPLICATED 오류를 발생시킨다.")
         void date_duplicated() throws Exception {
             // GIVEN
             em.persist(place1);
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseRepository.save(new Course(planet, TITLE, LocalDate.now()));
@@ -102,8 +102,8 @@ public class CreateTest {
         @DisplayName("장소가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_place() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -121,8 +121,8 @@ public class CreateTest {
         @DisplayName("코스를 저장한다.")
         void create() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 

--- a/src/test/java/trying/cosmos/test/course/service/DeleteTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/DeleteTest.java
@@ -58,7 +58,7 @@ public class DeleteTest {
         @DisplayName("코스가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> courseService.delete(user.getId(), NOT_EXIST))
@@ -69,11 +69,11 @@ public class DeleteTest {
         @DisplayName("사용자 행성의 코스가 아니면 NO_DATA 오류를 발생시킨다.")
         void others_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             Course course = courseRepository.save(new Course(planet, TITLE, now()));
 
-            User guest = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User guest = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> courseService.delete(guest.getId(), course.getId()))
@@ -89,8 +89,8 @@ public class DeleteTest {
         @DisplayName("코스를 삭제한다")
         void delete() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseService.create(user.getId(), TITLE, now(), course_place_request1);

--- a/src/test/java/trying/cosmos/test/course/service/FindByDateTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/FindByDateTest.java
@@ -59,8 +59,8 @@ public class FindByDateTest {
         @DisplayName("코스가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -78,8 +78,8 @@ public class FindByDateTest {
         @DisplayName("코스 정보를 반환한다.")
         void find() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseRepository.save(new Course(planet, TITLE, LocalDate.now()));

--- a/src/test/java/trying/cosmos/test/course/service/FindByIdTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/FindByIdTest.java
@@ -59,8 +59,8 @@ public class FindByIdTest {
         @DisplayName("코스가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -73,13 +73,13 @@ public class FindByIdTest {
         @DisplayName("사용자 행성의 코스가 아니면 NO_DATA 오류를 발생시킨다.")
         void others_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseRepository.save(new Course(planet, TITLE, LocalDate.now()));
 
-            User guest = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN));
+            User guest = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> courseService.find(guest.getId(), course.getId()))
@@ -95,8 +95,8 @@ public class FindByIdTest {
         @DisplayName("코스 정보를 반환한다.")
         void find() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseRepository.save(new Course(planet, TITLE, LocalDate.now()));

--- a/src/test/java/trying/cosmos/test/course/service/FindCourseExistDateTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/FindCourseExistDateTest.java
@@ -58,8 +58,8 @@ public class FindCourseExistDateTest {
         @DisplayName("시작 날짜와 끝 날짜 사이에 코스가 존재하는 날짜를 반환한다.")
         void find() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 

--- a/src/test/java/trying/cosmos/test/course/service/FindListTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/FindListTest.java
@@ -61,8 +61,8 @@ public class FindListTest {
         @DisplayName("likeonly 파라미터가 true면 좋아요한 코스만 반환한다.")
         void find_with_likeonly_true() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -88,8 +88,8 @@ public class FindListTest {
         @DisplayName("likeonly 파라미터가 false면 모든 코스를 반환한다.")
         void find_with_likeonly_false() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -115,8 +115,8 @@ public class FindListTest {
         @DisplayName("query 파라미터가 존재하면 해당 문자열을 제목에 포함하는 코스를 반환한다.")
         void find_with_query() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -142,8 +142,8 @@ public class FindListTest {
         @DisplayName("likeonly가 true고 query가 존재하면 두 조건을 모두 만족하는 코스를 반환한다")
         void find_with_query_and_likeonly() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 

--- a/src/test/java/trying/cosmos/test/course/service/LikeTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/LikeTest.java
@@ -61,8 +61,8 @@ public class LikeTest {
         @DisplayName("코스가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             
@@ -75,12 +75,12 @@ public class LikeTest {
         @DisplayName("사용자 행성의 코스가 아니라면 NO_DATA 오류를 발생시킨다.")
         void others_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
-            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN));
+            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN, true));
             Planet othersPlanet = planetRepository.save(new Planet(other, NAME2, IMAGE, INVITE_CODE));
             Course othersCourse = courseRepository.save(new Course(othersPlanet, TITLE, LocalDate.now()));
 
@@ -93,8 +93,8 @@ public class LikeTest {
         @DisplayName("이미 좋아요 되어있다면 DUPLICATED 오류를 발생시킨다.")
         void already_liked() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseRepository.save(new Course(planet, TITLE, LocalDate.now()));
@@ -116,8 +116,8 @@ public class LikeTest {
         @DisplayName("코스를 좋아요한다.")
         void like() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseRepository.save(new Course(planet, TITLE, LocalDate.now()));

--- a/src/test/java/trying/cosmos/test/course/service/LogTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/LogTest.java
@@ -61,8 +61,8 @@ public class LogTest {
         @DisplayName("리뷰가 있는 코스 정보를 최근 순서대로 반환한다.")
         void log() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 

--- a/src/test/java/trying/cosmos/test/course/service/UnlikeTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/UnlikeTest.java
@@ -61,8 +61,8 @@ public class UnlikeTest {
         @DisplayName("코스가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -75,12 +75,12 @@ public class UnlikeTest {
         @DisplayName("사용자 행성의 코스가 아니라면 NO_DATA 오류를 발생시킨다.")
         void others_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
-            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN));
+            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN, true));
             Planet othersPlanet = planetRepository.save(new Planet(other, NAME2, IMAGE, INVITE_CODE));
             Course othersCourse = courseRepository.save(new Course(othersPlanet, TITLE, LocalDate.now()));
             em.persist(new CourseLike(other, othersCourse));
@@ -94,8 +94,8 @@ public class UnlikeTest {
         @DisplayName("좋아요가 되어있지 않다면 NO_DATA 오류를 발생시킨다.")
         void not_liked() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseRepository.save(new Course(planet, TITLE, LocalDate.now()));
@@ -115,8 +115,8 @@ public class UnlikeTest {
         @DisplayName("코스 좋아요를 취소한다.")
         void unlike() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseRepository.save(new Course(planet, TITLE, LocalDate.now()));

--- a/src/test/java/trying/cosmos/test/course/service/UpdateTest.java
+++ b/src/test/java/trying/cosmos/test/course/service/UpdateTest.java
@@ -60,7 +60,7 @@ public class UpdateTest {
         @DisplayName("코스가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> courseService.update(user.getId(), NOT_EXIST, "UPDATED", now(), course_place_request1))
@@ -71,11 +71,11 @@ public class UpdateTest {
         @DisplayName("사용자 행성의 코스가 아니면 NO_DATA 오류를 발생시킨다.")
         void others_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             Course course = courseRepository.save(new Course(planet, TITLE, now()));
 
-            User guest = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User guest = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> courseService.update(guest.getId(), course.getId(), "UPDATED", now(), course_place_request1))
@@ -86,8 +86,8 @@ public class UpdateTest {
         @DisplayName("장소가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_place() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseService.create(user.getId(), TITLE, now(), course_place_request1);
@@ -106,8 +106,8 @@ public class UpdateTest {
         @DisplayName("코스를 수정한다")
         void update() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             Course course = courseService.create(user.getId(), TITLE, now(), course_place_request1);

--- a/src/test/java/trying/cosmos/test/notification/service/DeleteAllTest.java
+++ b/src/test/java/trying/cosmos/test/notification/service/DeleteAllTest.java
@@ -1,0 +1,64 @@
+package trying.cosmos.test.notification.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import trying.cosmos.domain.notification.entity.Notification;
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.notification.repository.NotificationRepository;
+import trying.cosmos.domain.notification.service.NotificationService;
+import trying.cosmos.domain.planet.entity.Planet;
+import trying.cosmos.domain.planet.repository.PlanetRepository;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.repository.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static trying.cosmos.test.TestVariables.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("알림 전체 삭제")
+public class DeleteAllTest {
+
+    @Autowired
+    NotificationService notificationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PlanetRepository planetRepository;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @Nested
+    @DisplayName("성공")
+    class success {
+
+        @Test
+        @DisplayName("알림을 최근 순서대로 반환")
+        void find() throws Exception {
+            // GIVEN
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
+            Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
+            planet.join(mate);
+
+            Notification notification1 = notificationRepository.save(new Notification(user, TITLE, BODY, NotificationTarget.COURSE, 1L));
+            Notification notification2 = notificationRepository.save(new Notification(user, TITLE, BODY, NotificationTarget.PLANET, null));
+            Notification notification3 = notificationRepository.save(new Notification(user, TITLE, BODY, NotificationTarget.REVIEW, 1L));
+
+            // WHEN
+            notificationService.deleteAll(user.getId());
+
+            // THEN
+            assertThat(notificationRepository.findByUser(user).size()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/trying/cosmos/test/notification/service/DeleteTest.java
+++ b/src/test/java/trying/cosmos/test/notification/service/DeleteTest.java
@@ -1,0 +1,62 @@
+package trying.cosmos.test.notification.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import trying.cosmos.domain.notification.entity.Notification;
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.notification.repository.NotificationRepository;
+import trying.cosmos.domain.notification.service.NotificationService;
+import trying.cosmos.domain.planet.entity.Planet;
+import trying.cosmos.domain.planet.repository.PlanetRepository;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.repository.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static trying.cosmos.test.TestVariables.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("알림 삭제")
+public class DeleteTest {
+
+    @Autowired
+    NotificationService notificationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PlanetRepository planetRepository;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @Nested
+    @DisplayName("성공")
+    class success {
+
+        @Test
+        @DisplayName("알림 삭제")
+        void find() throws Exception {
+            // GIVEN
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
+            Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
+            planet.join(mate);
+
+            Notification notification = notificationRepository.save(new Notification(user, TITLE, BODY, NotificationTarget.COURSE, 1L));
+
+            // WHEN
+            notificationService.delete(user.getId(), notification.getId());
+
+            // THEN
+            assertThat(notificationRepository.existsById(user.getId())).isFalse();
+        }
+    }
+}

--- a/src/test/java/trying/cosmos/test/notification/service/FindTest.java
+++ b/src/test/java/trying/cosmos/test/notification/service/FindTest.java
@@ -1,0 +1,66 @@
+package trying.cosmos.test.notification.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import trying.cosmos.domain.notification.entity.Notification;
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.notification.repository.NotificationRepository;
+import trying.cosmos.domain.notification.service.NotificationService;
+import trying.cosmos.domain.planet.entity.Planet;
+import trying.cosmos.domain.planet.repository.PlanetRepository;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.repository.UserRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static trying.cosmos.test.TestVariables.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("사용자 알림 조회")
+public class FindTest {
+
+    @Autowired
+    NotificationService notificationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PlanetRepository planetRepository;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+    
+    @Nested
+    @DisplayName("성공")
+    class success {
+        
+        @Test
+        @DisplayName("알림을 최근 순서대로 반환")
+        void find() throws Exception {
+            // GIVEN
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
+            Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
+            planet.join(mate);
+
+            Notification notification1 = notificationRepository.save(new Notification(user, TITLE, BODY, NotificationTarget.COURSE, 1L));
+            Notification notification2 = notificationRepository.save(new Notification(user, TITLE, BODY, NotificationTarget.PLANET, null));
+            Notification notification3 = notificationRepository.save(new Notification(user, TITLE, BODY, NotificationTarget.REVIEW, 1L));
+
+            // WHEN
+            List<Notification> notifications = notificationService.findByUser(user.getId());
+
+            // THEN
+            assertThat(notifications).containsExactly(notification3, notification2, notification1);
+        }
+    }
+}

--- a/src/test/java/trying/cosmos/test/notification/service/MarkAsReadTest.java
+++ b/src/test/java/trying/cosmos/test/notification/service/MarkAsReadTest.java
@@ -1,0 +1,62 @@
+package trying.cosmos.test.notification.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import trying.cosmos.domain.notification.entity.Notification;
+import trying.cosmos.domain.notification.entity.NotificationTarget;
+import trying.cosmos.domain.notification.repository.NotificationRepository;
+import trying.cosmos.domain.notification.service.NotificationService;
+import trying.cosmos.domain.planet.entity.Planet;
+import trying.cosmos.domain.planet.repository.PlanetRepository;
+import trying.cosmos.domain.user.entity.User;
+import trying.cosmos.domain.user.repository.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static trying.cosmos.test.TestVariables.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("알림 읽음 표시")
+public class MarkAsReadTest {
+
+    @Autowired
+    NotificationService notificationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PlanetRepository planetRepository;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @Nested
+    @DisplayName("성공")
+    class success {
+
+        @Test
+        @DisplayName("알림을 읽음으로 변경")
+        void find() throws Exception {
+            // GIVEN
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
+            Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
+            planet.join(mate);
+
+            Notification notification = notificationRepository.save(new Notification(user, TITLE, BODY, NotificationTarget.COURSE, 1L));
+
+            // WHEN
+            notificationService.markAsRead(user.getId(), notification.getId());
+
+            // THEN
+            assertThat(notification.isChecked()).isTrue();
+        }
+    }
+}

--- a/src/test/java/trying/cosmos/test/planet/service/CreateTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/CreateTest.java
@@ -38,7 +38,7 @@ public class CreateTest {
         @DisplayName("행성이 존재한다면 PLANET_CREATION_FAILED 오류를 발생시킨다.")
         void planet_exist() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             planetService.create(user.getId(), NAME1, IMAGE);
 
             // WHEN THEN
@@ -62,7 +62,7 @@ public class CreateTest {
         @DisplayName("행성을 생성한다.")
         void create() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN
             Planet planet = planetService.create(user.getId(), NAME1, IMAGE);

--- a/src/test/java/trying/cosmos/test/planet/service/FindTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/FindTest.java
@@ -52,8 +52,8 @@ public class FindTest {
         @DisplayName("행성에 빈 자리가 없으면 NO_DATA 오류를 발생시킨다.")
         void planet_is_full() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -72,7 +72,7 @@ public class FindTest {
         @DisplayName("행성을 조회한다.")
         void find() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
 
             // WHEN

--- a/src/test/java/trying/cosmos/test/planet/service/JoinTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/JoinTest.java
@@ -45,7 +45,7 @@ public class JoinTest {
         @DisplayName("행성이 존재하지 않는다면 NO_DATA 오류를 발생시킨다.")
         void no_planet() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> planetService.join(user.getId(), WRONG_INVITE_CODE))
@@ -56,11 +56,11 @@ public class JoinTest {
         @DisplayName("행성에 빈 자리가 없으면 NO_DATA 오류를 발생시킨다.")
         void planet_is_full() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
-            User guest = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN));
+            User guest = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> planetService.join(guest.getId(), INVITE_CODE))
@@ -72,7 +72,7 @@ public class JoinTest {
         @DisplayName("내 행성이면 PLANET_JOIN_FAILED 오류를 발생시킨다.")
         void my_planet() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             
             // WHEN THEN
@@ -97,8 +97,8 @@ public class JoinTest {
         @DisplayName("행성 참가")
         void join() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
 
             // WHEN

--- a/src/test/java/trying/cosmos/test/planet/service/LeaveTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/LeaveTest.java
@@ -42,7 +42,7 @@ public class LeaveTest {
         @DisplayName("행성이 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_planet() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> planetService.leave(user.getId()))
@@ -66,8 +66,8 @@ public class LeaveTest {
         @DisplayName("행성을 나간 후 빈 행성이 아니라면 유지한다.")
         void leave() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -93,7 +93,7 @@ public class LeaveTest {
         @DisplayName("행성을 나간 후 빈 행성이라면 행성을 삭제한다.")
         void leave_empty() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
 
             // WHEN

--- a/src/test/java/trying/cosmos/test/planet/service/UpdateTest.java
+++ b/src/test/java/trying/cosmos/test/planet/service/UpdateTest.java
@@ -44,7 +44,7 @@ public class UpdateTest {
         @DisplayName("행성이 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_planet() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // THEN WHEN
             assertThatThrownBy(() -> planetService.update(user.getId(), "UPDATED", LocalDate.now(), IMAGE))
@@ -61,7 +61,7 @@ public class UpdateTest {
         @DisplayName("행성 정보를 수정한다.")
         void update() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
 
             // WHEN

--- a/src/test/java/trying/cosmos/test/review/service/CreateTest.java
+++ b/src/test/java/trying/cosmos/test/review/service/CreateTest.java
@@ -61,8 +61,8 @@ public class CreateTest {
         @DisplayName("코스가 존재하지 않으면 NO_DATA 오류를 발생시킨다.")
         void no_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
             
@@ -75,12 +75,12 @@ public class CreateTest {
         @DisplayName("사용자 행성의 코스가 아니라면 NO_DATA 오류를 발생시킨다.")
         void others_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
-            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN));
+            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN, true));
             Planet othersPlanet = planetRepository.save(new Planet(other, NAME2, IMAGE, INVITE_CODE));
             Course othersCourse = courseRepository.save(new Course(othersPlanet, TITLE, LocalDate.now()));
             
@@ -93,8 +93,8 @@ public class CreateTest {
         @DisplayName("리뷰가 존재한다면 DUPLICATED 오류를 발생시킨다.")
         void already_reviewed() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -117,8 +117,8 @@ public class CreateTest {
         @DisplayName("코스 리뷰를 생성한다")
         void create() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 

--- a/src/test/java/trying/cosmos/test/review/service/DeleteTest.java
+++ b/src/test/java/trying/cosmos/test/review/service/DeleteTest.java
@@ -61,12 +61,12 @@ public class DeleteTest {
         @DisplayName("사용자 행성의 코스가 아니라면 NO_DATA 오류를 발생시킨다.")
         void others_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
-            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN));
+            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN, true));
             Planet othersPlanet = planetRepository.save(new Planet(other, NAME2, IMAGE, INVITE_CODE));
             Course othersCourse = courseRepository.save(new Course(othersPlanet, TITLE, LocalDate.now()));
 
@@ -81,8 +81,8 @@ public class DeleteTest {
         @DisplayName("리뷰가 존재하지 않는다면 NO_DATA 오류를 발생시킨다.")
         void not_reviewed() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -103,8 +103,8 @@ public class DeleteTest {
         @DisplayName("코스 리뷰를 삭제한다")
         void delete() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 

--- a/src/test/java/trying/cosmos/test/review/service/UpdateTest.java
+++ b/src/test/java/trying/cosmos/test/review/service/UpdateTest.java
@@ -61,12 +61,12 @@ public class UpdateTest {
         @DisplayName("사용자의 리뷰가 아니라면 NO_DATA 오류를 발생시킨다.")
         void others_course() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
-            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN));
+            User other = userRepository.save(User.createEmailUser(EMAIL3, PASSWORD, NAME3, DEVICE_TOKEN, true));
             Planet othersPlanet = planetRepository.save(new Planet(other, NAME2, IMAGE, INVITE_CODE));
             Course othersCourse = courseRepository.save(new Course(othersPlanet, TITLE, LocalDate.now()));
 
@@ -81,8 +81,8 @@ public class UpdateTest {
         @DisplayName("리뷰가 존재하지 않는다면 NO_DATA 오류를 발생시킨다.")
         void not_reviewed() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 
@@ -103,8 +103,8 @@ public class UpdateTest {
         @DisplayName("코스 리뷰를 수정한다.")
         void update() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
-            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
+            User mate = userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Planet planet = planetRepository.save(new Planet(user, NAME1, IMAGE, INVITE_CODE));
             planet.join(mate);
 

--- a/src/test/java/trying/cosmos/test/user/service/JoinByEmailTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/JoinByEmailTest.java
@@ -60,7 +60,7 @@ public class JoinByEmailTest {
         @DisplayName("인증 객체가 존재하지 않으면 NOT_CERTIFICATED 오류를 발생시킨다.")
         void no_certification() throws Exception {
             // WHEN THEN
-            assertThatThrownBy(() -> userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN))
+            assertThatThrownBy(() -> userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ExceptionType.NOT_CERTIFICATED.getMessage());
         }
@@ -72,7 +72,7 @@ public class JoinByEmailTest {
             certificationService.generate(EMAIL1);
 
             // WHEN THEN
-            assertThatThrownBy(() -> userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN))
+            assertThatThrownBy(() -> userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ExceptionType.NOT_CERTIFICATED.getMessage());
         }
@@ -81,12 +81,12 @@ public class JoinByEmailTest {
         @DisplayName("이메일에 해당하는 사용자가 존재한다면 EMAIL_DUPLICATED 오류를 발생시킨다.")
         void email_duplicated() throws Exception {
             // GIVEN
-            userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME2, DEVICE_TOKEN));
+            userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME2, DEVICE_TOKEN, true));
             Certification certification = certificationRepository.save(new Certification(EMAIL1));
             certificationService.certificate(EMAIL1, certification.getCode());
 
             // WHEN THEN
-            assertThatThrownBy(() -> userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN))
+            assertThatThrownBy(() -> userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ExceptionType.EMAIL_DUPLICATED.getMessage());
         }
@@ -94,12 +94,12 @@ public class JoinByEmailTest {
         @Test
         @DisplayName("닉네임에 해당하는 사용자가 존재한다면 NAME_DUPLICATED 오류를 발생시킨다.")
         void name_duplicated() throws Exception {
-            userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME1, DEVICE_TOKEN));
+            userRepository.save(User.createEmailUser(EMAIL2, PASSWORD, NAME1, DEVICE_TOKEN, true));
             String code = certificationRepository.save(new Certification(EMAIL1)).getCode();
             certificationService.certificate(EMAIL1, code);
 
             // WHEN THEN
-            assertThatThrownBy(() -> userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN))
+            assertThatThrownBy(() -> userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ExceptionType.NAME_DUPLICATED.getMessage());
         }
@@ -124,7 +124,7 @@ public class JoinByEmailTest {
             certificationService.certificate(EMAIL1, certification.getCode());
 
             // WHEN
-            userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN);
+            userService.join(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true);
 
             // THEN
             assertThat(certificationRepository.findByEmail(EMAIL1)).isEmpty();

--- a/src/test/java/trying/cosmos/test/user/service/JoinBySocialTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/JoinBySocialTest.java
@@ -42,10 +42,10 @@ public class JoinBySocialTest {
         @DisplayName("식별자가 존재한다면 IDENTIFIER_DUPLICATED 오류를 발생시킨다.")
         void identifier_duplicated() throws Exception {
             // GIVEN
-            socialAccountService.join(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN);
+            socialAccountService.join(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN, true);
 
             // WHEN THEN
-            assertThatThrownBy(() -> socialAccountService.join(IDENTIFIER1, EMAIL2, NAME2, DEVICE_TOKEN))
+            assertThatThrownBy(() -> socialAccountService.join(IDENTIFIER1, EMAIL2, NAME2, DEVICE_TOKEN, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ExceptionType.IDENTIFIER_DUPLICATED.getMessage());
         }
@@ -54,10 +54,10 @@ public class JoinBySocialTest {
         @DisplayName("이메일이 존재한다면 EMAIL_DUPLICATED 오류를 발생시킨다.")
         void email_duplicated() throws Exception {
             // GIVEN
-            socialAccountService.join(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN);
+            socialAccountService.join(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN, true);
 
             // WHEN THEN
-            assertThatThrownBy(() -> socialAccountService.join(IDENTIFIER2, EMAIL1, NAME2, DEVICE_TOKEN))
+            assertThatThrownBy(() -> socialAccountService.join(IDENTIFIER2, EMAIL1, NAME2, DEVICE_TOKEN, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ExceptionType.EMAIL_DUPLICATED.getMessage());
         }
@@ -66,10 +66,10 @@ public class JoinBySocialTest {
         @DisplayName("닉네임이 존재한다면 NAME_DUPLICATED 오류를 발생시킨다.")
         void name_duplicated() throws Exception {
             // GIVEN
-            socialAccountService.join(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN);
+            socialAccountService.join(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN, true);
 
             // WHEN THEN
-            assertThatThrownBy(() -> socialAccountService.join(IDENTIFIER2, EMAIL2, NAME1, DEVICE_TOKEN))
+            assertThatThrownBy(() -> socialAccountService.join(IDENTIFIER2, EMAIL2, NAME1, DEVICE_TOKEN, true))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ExceptionType.NAME_DUPLICATED.getMessage());
         }
@@ -90,7 +90,7 @@ public class JoinBySocialTest {
         @DisplayName("소셜 회원 가입")
         void join() throws Exception {
             // WHEN
-            socialAccountService.join(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN);
+            socialAccountService.join(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN, true);
 
             // THEN
             assertThat(userRepository.findByIdentifier(IDENTIFIER1)).isPresent();

--- a/src/test/java/trying/cosmos/test/user/service/LoginByEmailTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/LoginByEmailTest.java
@@ -67,7 +67,7 @@ public class LoginByEmailTest {
         @DisplayName("비밀번호가 일치하지 않으면 INVALID_PASSWORD 오류를 발생시킨다.")
         void wrong_password() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             
             // WHEN THEN
             assertThatThrownBy(() -> userService.login(EMAIL1, WRONG_PASSWORD, DEVICE_TOKEN))
@@ -79,7 +79,7 @@ public class LoginByEmailTest {
         @DisplayName("정지된 사용자라면 SUSPENDED_USER 오류를 발생시킨다.")
         void suspended_user() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             user.setStatus(UserStatus.SUSPENDED);
 
             // WHEN THEN
@@ -92,7 +92,7 @@ public class LoginByEmailTest {
         @DisplayName("삭제된 사용자라면 NO_DATA 오류를 발생시킨다.")
         void withdrawn_user() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             user.setStatus(UserStatus.WITHDRAWN);
 
             // WHEN THEN
@@ -117,7 +117,7 @@ public class LoginByEmailTest {
         @DisplayName("세션이 존재하지 않으면 새로운 세션을 생성한다.")
         void session_not_exist() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN
             String token = userService.login(EMAIL1, PASSWORD, DEVICE_TOKEN);
@@ -140,7 +140,7 @@ public class LoginByEmailTest {
         @DisplayName("세션이 존재하면 기존 세션을 삭제하고 새로운 세션을 생성한다.")
         void session_exist() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             userService.login(EMAIL1, PASSWORD, DEVICE_TOKEN);
             Session session = sessionRepository.findByUserId(user.getId()).orElseThrow();
 

--- a/src/test/java/trying/cosmos/test/user/service/LoginBySocialTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/LoginBySocialTest.java
@@ -57,7 +57,7 @@ public class LoginBySocialTest {
         @DisplayName("정지된 사용자라면 SUSPENDED_USER 오류를 발생시킨다.")
         void suspended_user() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, PASSWORD, NAME1));
+            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, PASSWORD, NAME1, true));
             user.setStatus(UserStatus.SUSPENDED);
 
             // WHEN THEN
@@ -70,7 +70,7 @@ public class LoginBySocialTest {
         @DisplayName("삭제된 사용자라면 NO_DATA 오류를 발생시킨다.")
         void withdrawn_user() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, PASSWORD, NAME1));
+            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, PASSWORD, NAME1, true));
             user.setStatus(UserStatus.WITHDRAWN);
 
             // WHEN THEN
@@ -95,7 +95,7 @@ public class LoginBySocialTest {
         @DisplayName("세션이 존재하지 않으면 새로운 세션을 생성한다.")
         void session_not_exist() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN, true));
 
             // WHEN
             String token = socialAccountService.login(IDENTIFIER1, DEVICE_TOKEN);
@@ -119,7 +119,7 @@ public class LoginBySocialTest {
         @DisplayName("세션이 존재하면 기존 세션을 삭제하고 새로운 세션을 생성한다.")
         void session_exist() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN, true));
             socialAccountService.login(IDENTIFIER1, DEVICE_TOKEN);
             Session session = sessionRepository.findByUserId(user.getId()).orElseThrow();
 

--- a/src/test/java/trying/cosmos/test/user/service/ResetPasswordTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/ResetPasswordTest.java
@@ -49,7 +49,7 @@ public class ResetPasswordTest {
         @DisplayName("정지된 사용자라면 SUSPENDED_USER 오류를 발생시킨다.")
         void suspended_user() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             user.setStatus(UserStatus.SUSPENDED);
 
             // WHEN THEN
@@ -62,7 +62,7 @@ public class ResetPasswordTest {
         @DisplayName("삭제된 사용자라면 NO_DATA 오류를 발생시킨다.")
         void withdrawn_user() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
             user.setStatus(UserStatus.WITHDRAWN);
 
             // WHEN THEN
@@ -75,7 +75,7 @@ public class ResetPasswordTest {
         @DisplayName("소셜 회원가입한 사용자라면 SOCIAL_ACCOUNT 오류를 발생시킨다.")
         void social_account() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createSocialUser(IDENTIFIER1, EMAIL1, NAME1, DEVICE_TOKEN, true));
 
             // WHEN THEN
             assertThatThrownBy(() -> userService.resetPassword(EMAIL1))
@@ -98,7 +98,7 @@ public class ResetPasswordTest {
         @DisplayName("비밀번호를 초기화한다.")
         void reset_password() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN
             userService.resetPassword(EMAIL1);

--- a/src/test/java/trying/cosmos/test/user/service/UpdateNameTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/UpdateNameTest.java
@@ -34,7 +34,7 @@ public class UpdateNameTest {
         @DisplayName("사용자 닉네임을 변경한다.")
         void update_name() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN
             userService.updateName(user.getId(), "UPDATED");

--- a/src/test/java/trying/cosmos/test/user/service/UpdatePasswordTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/UpdatePasswordTest.java
@@ -35,7 +35,7 @@ public class UpdatePasswordTest {
         @DisplayName("사용자 비밀번호를 변경한다.")
         void update_password() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN
             userService.updatePassword(user.getId(), "UPDATED");

--- a/src/test/java/trying/cosmos/test/user/service/WithdrawTest.java
+++ b/src/test/java/trying/cosmos/test/user/service/WithdrawTest.java
@@ -35,7 +35,7 @@ public class WithdrawTest {
         @DisplayName("사용자 계정을 삭제한다.")
         void withdraw() throws Exception {
             // GIVEN
-            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN));
+            User user = userRepository.save(User.createEmailUser(EMAIL1, PASSWORD, NAME1, DEVICE_TOKEN, true));
 
             // WHEN
             userService.withdraw(user.getId());


### PR DESCRIPTION
## 🔍 Issue
- Close #95 

## 📝 Task
- 메이트 행성 참가, 코스 생성, 데이트 하루 전, 리뷰 생성 시 푸시 알림 기능 추가
- 테스트 코드 작성

## 🧐 Reference
- [@Scheduled 사용법, 스케줄러 커스터마이징을 통한 제어(+스케줄러에 등록한 작업 중지하는 방법, 배치 효과, 정확한 주기 작업 사용법)](https://jeong-pro.tistory.com/186)
- [JPA exists 쿼리 성능 개선](https://jojoldu.tistory.com/516)
